### PR TITLE
Simplify Banny landing layout

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,192 +1,161 @@
 "use client";
 
-import React, { useState, useRef, useCallback } from "react";
-import Head from "next/head";
-import { toPng } from "html-to-image";
+import Link from "next/link";
 import { motion } from "framer-motion";
-import { Download } from "lucide-react";
+import { Layers, Palette, Rocket, Ruler, Stars, Type } from "lucide-react";
 
-import AppLayout from "@/components/AppLayout";
-import Sidebar from "@/components/Sidebar/Sidebar";
-import BannerPreview from "@/components/Preview/BannerPreview";
-import SettingsPanel from "@/components/Settings/SettingsPanel";
-import { patterns } from "@/constants/patterns";
-import { parseCSS } from "@/utils/parseCSS";
-import { TextStyles } from "@/types";
+const heroStats = [
+    { label: "Unique Banner Presets", value: "150+" },
+    { label: "Export Quality", value: "4K" },
+    { label: "Satisfied Creators", value: "25K" },
+];
 
-const Page: React.FC = () => {
-    const previewRef = useRef<HTMLDivElement>(null);
+const features = [
+    {
+        title: "Schriftstil",
+        description:
+            "Setze Headlines, Claims und CTA-Texte mit feinfühligen Typo-Controls in Szene.",
+        icon: Type,
+    },
+    {
+        title: "Schriftgröße",
+        description:
+            "Passe Größen, Abstände und Rhythmus präzise an, damit jede Zeile perfekt sitzt.",
+        icon: Ruler,
+    },
+    {
+        title: "15+ Schriftarten",
+        description:
+            "Wähle aus einer kuratierten Bibliothek, abgestimmt auf Marken mit Charakter.",
+        icon: Palette,
+    },
+    {
+        title: "20+ Banner",
+        description:
+            "Starte mit wandelbaren Vorlagen für Launches, Drops, Events und mehr.",
+        icon: Layers,
+    },
+];
 
-    /* ----------------------------- Pattern State ----------------------------- */
-    const [selectedPattern, setSelectedPattern] = useState(patterns[0]);
-    const [patternColor1, setPatternColor1] = useState("#131313");
-    const [patternColor2, setPatternColor2] = useState("#b3b3c4");
-    const [patternScale, setPatternScale] = useState(10);
-
-    /* ----------------------------- Text State -------------------------------- */
-    const [textContent, setTextContent] = useState("Text");
-    const [textStyles, setTextStyles] = useState<TextStyles>({
-        bold: false,
-        italic: false,
-        underline: false,
-        strikethrough: false,
-        noWrap: false,
-        fontSize: 128,
-        alignment: "center",
-        textColor: "var(--foreground)",
-        fontFamily: "Arial",
-    });
-
-    /* ----------------------------- UI State ---------------------------------- */
-    const [visiblePicker, setVisiblePicker] = useState<string | null>(null);
-    const darkMode = true; // placeholder – swap with real theme toggle if available
-
-    /* ----------------------------- Callbacks --------------------------------- */
-    const togglePicker = useCallback((id: string) => {
-        setVisiblePicker((current) => (current === id ? null : id));
-    }, []);
-
-    const toggleStyle = useCallback((style: keyof TextStyles) => {
-        setTextStyles((prev) => ({ ...prev, [style]: !prev[style] }));
-    }, []);
-
-    const handleExportAsPNG = async () => {
-        if (!previewRef.current) return;
-
-        try {
-            const dataURL = await toPng(previewRef.current, { pixelRatio: 3 });
-            const link = document.createElement("a");
-            link.href = dataURL;
-            link.download = "banner-preview-highres.png";
-            link.click();
-        } catch (error) {
-            console.error("Error exporting high-res PNG:", error);
-        }
-    };
-
-    /* ------------------------------------------------------------------------ */
+const Page = () => {
     return (
-        <AppLayout>
-            {/* ------------------------------------------------------------------- */}
-            <Head>
-                <link
-                    href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Pacifico&family=Times+New+Roman&display=swap"
-                    rel="stylesheet"
-                />
-            </Head>
-
-            {/* --------------------- Global Download Button ------------------------ */}
-            <motion.button
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.95 }}
-                onClick={handleExportAsPNG}
-                className="fixed top-4 right-4 z-50 flex items-center gap-2
-                 rounded-lg bg-indigo-600/90 px-4 py-2
-                 text-sm font-semibold text-white
-                 shadow-lg ring-1 ring-white/20 backdrop-blur-md
-                 transition-colors hover:bg-indigo-500 focus:outline-none"
-            >
-                <Download size={18} strokeWidth={2} />
-                Download
-            </motion.button>
-
-            {/* ------------------------------ Layout ------------------------------ */}
-            <div className="min-h-screen flex flex-col md:flex-row bg-zinc-900 text-foreground transition-colors duration-300">
-                {/* --------------------------- Sidebar --------------------------- */}
-                <Sidebar
-                    toggleStyle={toggleStyle}
-                    changeFontSize={(size) => setTextStyles((s) => ({ ...s, fontSize: size }))}
-                    changeAlignment={(a) => setTextStyles((s) => ({ ...s, alignment: a }))}
-                    currentFontSize={textStyles.fontSize}
-                    changeTextColor={(c) => setTextStyles((s) => ({ ...s, textColor: c }))}
-                    changeFontFamily={(f) => setTextStyles((s) => ({ ...s, fontFamily: f }))}
-                    noWrap={textStyles.noWrap}
-                    toggleNoWrap={() => setTextStyles((s) => ({ ...s, noWrap: !s.noWrap }))}
-                    darkMode={darkMode}
-                    visiblePicker={visiblePicker}
-                    togglePicker={togglePicker}
-                    patternScale={patternScale}
-                    setPatternScale={setPatternScale}
-                    onEmojiSelect={(emoji) => setTextContent((prev) => prev + emoji)}
-                />
-
-                {/* --------------------------- Main ------------------------------ */}
-                <main className="flex-1 p-4 md:overflow-y-auto">
-                    <div className="w-full max-w-screen-lg mx-auto space-y-16">
-                        {/* Preview ----------------------------------------------------- */}
-                        <BannerPreview
-                            selectedPattern={selectedPattern}
-                            patternColor1={patternColor1}
-                            patternColor2={patternColor2}
-                            patternScale={patternScale}
-                            textContent={textContent}
-                            textStyles={textStyles}
-                            previewRef={previewRef}
-                        />
-
-                        {/* Settings ---------------------------------------------------- */}
-                        <SettingsPanel
-                            patternColor1={patternColor1}
-                            setPatternColor1={setPatternColor1}
-                            patternColor2={patternColor2}
-                            setPatternColor2={setPatternColor2}
-                            patternScale={patternScale}
-                            setPatternScale={setPatternScale}
-                            darkMode={darkMode}
-                            visiblePicker={visiblePicker}
-                            togglePicker={togglePicker}
-                        />
-
-                        {/* Pattern Carousel ------------------------------------------- */}
-                        <section className="w-full relative z-0">{/*  <-- hier: relative  */}
-                            <div
-                                /* eigener Stacking-Context für die Cards                          */
-                                className="
-      relative z-10
-      flex gap-6 overflow-x-auto
-      px-6 pt-6 pb-6 snap-x snap-mandatory scroll-smooth
-    "
-                            >
-                                {patterns.map((pattern) => {
-                                    const isSelected = selectedPattern?.name === pattern.name
-                                    return (
-                                        <motion.div
-                                            key={pattern.name}
-                                            whileHover={{ scale: 1.05 }}
-                                            whileTap={{ scale: 0.97 }}
-                                            onClick={() => setSelectedPattern(pattern)}
-                                            className={`
-            relative w-56 h-40 shrink-0 rounded-xl cursor-pointer
-            transition duration-150
-            bg-zinc-900/60 backdrop-blur-md shadow-md hover:shadow-lg
-            ring-1 ring-white/10
-            ${isSelected
-                                                ? "ring-2 ring-indigo-500"
-                                                : "hover:ring-1 hover:ring-indigo-300"}
-          `}
-                                            style={parseCSS(pattern.style, 5, "#131313", "#b3b3c4")}
-                                        >
-          <span
-              className="
-              absolute top-2 left-2 rounded
-              bg-zinc-900/80 backdrop-blur px-2 py-0.5
-              text-[10px] font-semibold tracking-wider uppercase
-              text-foreground/70 ring-1 ring-white/10
-            "
-          >
-            {pattern.name}
-          </span>
-                                        </motion.div>
-                                    )
-                                })}
-                            </div>
-                        </section>
-
-
-                    </div>
-                </main>
+        <div className="relative min-h-screen overflow-hidden bg-zinc-950 text-white">
+            {/* Background orbs */}
+            <div className="pointer-events-none absolute inset-0 overflow-hidden">
+                <div className="absolute -top-32 -left-24 h-[28rem] w-[28rem] rounded-full bg-indigo-600/30 blur-3xl" />
+                <div className="absolute top-1/4 -right-40 h-[32rem] w-[32rem] rounded-full bg-emerald-500/20 blur-3xl" />
+                <div className="absolute bottom-0 left-1/2 h-[24rem] w-[24rem] -translate-x-1/2 rounded-full bg-sky-500/10 blur-3xl" />
             </div>
-        </AppLayout>
+
+            <div className="relative z-10 mx-auto flex w-full max-w-6xl flex-col gap-24 px-6 pb-24 pt-12 md:px-10 lg:px-16">
+                {/* Navigation */}
+                <header className="flex items-center justify-between">
+                    <div className="flex items-center gap-6">
+                        <div className="flex h-20 w-20 items-center justify-center rounded-3xl border border-white/20 bg-white/5 text-2xl font-semibold uppercase tracking-[0.3em] text-white/80 shadow-xl shadow-indigo-500/10">
+                            Logo
+                        </div>
+                        <div>
+                            <span className="text-sm uppercase tracking-[0.4em] text-white/60">Banny</span>
+                            <h1 className="text-2xl font-semibold">Banner Alchemy Studio</h1>
+                        </div>
+                    </div>
+                </header>
+
+                {/* Hero */}
+                <section className="space-y-10">
+                    <div className="space-y-10">
+                        <motion.div
+                            initial={{ opacity: 0, y: 20 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ duration: 0.6 }}
+                            className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-sm text-white/70"
+                        >
+                            <Stars className="h-4 w-4 text-indigo-300" />
+                            Banny — der Creator für magnetische Banner
+                        </motion.div>
+
+                        <motion.h2
+                            initial={{ opacity: 0, y: 24 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ delay: 0.1, duration: 0.7 }}
+                            className="text-4xl font-semibold leading-tight text-white md:text-5xl lg:text-6xl"
+                        >
+                            Kreiere Banner, die Geschichten erzählen und Communities entzünden.
+                        </motion.h2>
+
+                        <motion.p
+                            initial={{ opacity: 0, y: 24 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ delay: 0.2, duration: 0.7 }}
+                            className="max-w-xl text-lg leading-relaxed text-white/70"
+                        >
+                            Banny kombiniert dynamisches Design mit intuitiver Bedienung. In wenigen Klicks setzt du farbenstarke Visuals in Szene, synchronisiert mit deiner Marke und bereit für jeden Launch.
+                        </motion.p>
+
+                        <motion.div
+                            initial={{ opacity: 0, y: 24 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ delay: 0.3, duration: 0.7 }}
+                            className="flex flex-wrap items-center gap-4"
+                        >
+                            <Link
+                                href="#"
+                                className="inline-flex items-center gap-3 rounded-full bg-gradient-to-r from-indigo-500 via-purple-500 to-rose-500 px-6 py-3 text-sm font-semibold uppercase tracking-wider text-white shadow-xl shadow-indigo-500/30 transition hover:-translate-y-1 hover:shadow-2xl"
+                            >
+                                Launch den Creator
+                                <Rocket className="h-4 w-4" />
+                            </Link>
+                            <Link
+                                href="#features"
+                                className="inline-flex items-center gap-2 rounded-full border border-white/20 px-5 py-3 text-sm font-semibold text-white/80 backdrop-blur transition hover:border-white/40 hover:text-white"
+                            >
+                                Studio-Stimmungen ansehen
+                            </Link>
+                        </motion.div>
+
+                        <motion.div
+                            initial={{ opacity: 0, y: 24 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ delay: 0.4, duration: 0.7 }}
+                            className="grid grid-cols-1 gap-4 text-white/70 sm:grid-cols-3"
+                        >
+                            {heroStats.map((stat) => (
+                                <div key={stat.label} className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                                    <div className="text-3xl font-semibold text-white">{stat.value}</div>
+                                    <div className="text-xs uppercase tracking-[0.3em] text-white/60">
+                                        {stat.label}
+                                    </div>
+                                </div>
+                            ))}
+                        </motion.div>
+                    </div>
+                </section>
+
+                {/* Features */}
+                <section id="features" className="space-y-16">
+                    <div className="flex items-center gap-3 text-white/60">
+                        <Layers className="h-5 w-5" />
+                        <span className="text-xs uppercase tracking-[0.4em]">Features</span>
+                    </div>
+                    <h2 className="text-3xl font-semibold md:text-4xl">Mehr Charakter in jedem Banner</h2>
+                    <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+                        {features.map((feature) => (
+                            <motion.div
+                                key={feature.title}
+                                whileHover={{ y: -6 }}
+                                className="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur"
+                            >
+                                <div className="absolute inset-0 bg-gradient-to-br from-white/0 via-white/5 to-white/0 opacity-0 transition group-hover:opacity-100" />
+                                <feature.icon className="h-10 w-10 text-indigo-300" />
+                                <h3 className="mt-6 text-xl font-semibold text-white">{feature.title}</h3>
+                                <p className="mt-4 text-sm leading-relaxed text-white/70">{feature.description}</p>
+                            </motion.div>
+                        ))}
+                    </div>
+                </section>
+
+            </div>
+        </div>
     );
 };
 


### PR DESCRIPTION
## Summary
- remove the right-side hero Vibe Sequencer panel and keep the hero copy left-aligned with the enlarged logo header
- refresh the features grid with typography-focused highlights for Schriftstil, Schriftgröße, curated fonts, and banner templates
- drop the testimonial and CTA footer sections to match the streamlined brief

## Testing
- npm run lint *(fails: pre-existing ESLint errors in sidebar components)*

------
https://chatgpt.com/codex/tasks/task_e_68e56e70254483249153bfbc132c37c7