### PR TITLE
Adjust creator layout scroll and preview sizing

### DIFF
--- a/src/app/creator/page.tsx
+++ b/src/app/creator/page.tsx
@@ -30,6 +30,7 @@ const CreatorPage = () => {
     const [patternColor2, setPatternColor2] = useState("#b3b3c4");
     const [patternScale, setPatternScale] = useState(14);
     const [visiblePicker, setVisiblePicker] = useState<string | null>(null);
+    const [isFontPanelOpen, setIsFontPanelOpen] = useState(true);
 
     const previewRef = useRef<HTMLDivElement>(null);
     const darkMode = true;
@@ -128,93 +129,110 @@ const CreatorPage = () => {
                     initial={{ opacity: 0, y: 32 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ duration: 0.7 }}
-                    className="grid gap-8 xl:grid-cols-[minmax(18rem,22rem)_1fr_minmax(18rem,21rem)]"
+                    className="flex flex-col gap-8"
                 >
-                    <div className="rounded-3xl border border-[#A1E2F8]/15 bg-white/5 p-1 backdrop-blur-xl shadow-[0_20px_60px_-20px_rgba(192,230,244,0.35)]">
-                        <Sidebar
-                            toggleStyle={toggleStyle}
-                            changeFontSize={changeFontSize}
-                            changeAlignment={changeAlignment}
-                            currentFontSize={textStyles.fontSize}
-                            changeTextColor={changeTextColor}
-                            changeFontFamily={changeFontFamily}
-                            noWrap={textStyles.noWrap}
-                            toggleNoWrap={toggleNoWrap}
-                            darkMode={darkMode}
-                            visiblePicker={visiblePicker}
-                            togglePicker={togglePicker}
-                            patternScale={patternScale}
-                            setPatternScale={setPatternScale}
-                            onEmojiSelect={handleEmojiSelect}
-                        />
-                    </div>
-
-                    <div className="flex flex-col gap-6">
-                        <div className="rounded-3xl border border-[#A1E2F8]/20 bg-white/5 p-6 backdrop-blur-xl shadow-[0_25px_80px_-35px_rgba(192,230,244,0.55)]">
-                            <div className="mb-4 flex items-center justify-between text-sm uppercase tracking-[0.35em] text-[#A1E2F8]/70">
-                                <span>Preview</span>
-                                <span>{textStyles.fontSize}px</span>
-                            </div>
-                            <div className="overflow-hidden rounded-2xl border border-white/10 bg-black/40">
-                                <BannerPreview
-                                    selectedPattern={selectedPattern}
-                                    patternColor1={patternColor1}
-                                    patternColor2={patternColor2}
+                    <div className="flex flex-col gap-8 xl:flex-row xl:items-start xl:gap-12">
+                        <div className="flex w-full flex-col gap-4 xl:sticky xl:top-24 xl:w-72 xl:self-start">
+                            <button
+                                type="button"
+                                aria-expanded={isFontPanelOpen}
+                                onClick={() => setIsFontPanelOpen((prev) => !prev)}
+                                className="flex items-center justify-between rounded-full border border-white/10 bg-white/5 px-5 py-3 text-sm font-medium tracking-[0.2em] uppercase text-white/70 transition hover:border-[#A1E2F8]/40 hover:text-white"
+                            >
+                                <span>Schriftoptionen</span>
+                                <span className="text-xs text-[#A1E2F8]">{isFontPanelOpen ? "Einklappen" : "Ausklappen"}</span>
+                            </button>
+                            {isFontPanelOpen && (
+                                <Sidebar
+                                    toggleStyle={toggleStyle}
+                                    changeFontSize={changeFontSize}
+                                    changeAlignment={changeAlignment}
+                                    currentFontSize={textStyles.fontSize}
+                                    changeTextColor={changeTextColor}
+                                    changeFontFamily={changeFontFamily}
+                                    noWrap={textStyles.noWrap}
+                                    toggleNoWrap={toggleNoWrap}
+                                    darkMode={darkMode}
+                                    visiblePicker={visiblePicker}
+                                    togglePicker={togglePicker}
                                     patternScale={patternScale}
-                                    textContent={textContent}
-                                    textStyles={textStyles}
-                                    previewRef={previewRef}
-                                    onTextChange={setTextContent}
+                                    setPatternScale={setPatternScale}
+                                    onEmojiSelect={handleEmojiSelect}
                                 />
-                            </div>
+                            )}
                         </div>
 
-                        <div className="rounded-3xl border border-[#A1E2F8]/10 bg-white/5 p-6 backdrop-blur-xl shadow-[0_20px_60px_-35px_rgba(192,230,244,0.45)]">
-                            <h2 className="text-lg font-semibold text-white">Pattern auswählen</h2>
-                            <p className="mt-2 text-sm text-white/60">
-                                Feine Texturen für lebendige Banner. Justiere Farben und Skalierung, um deinen Look zu perfektionieren.
-                            </p>
-                            <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-                                {patterns.map((pattern) => (
-                                    <button
-                                        key={pattern.name}
-                                        type="button"
-                                        onClick={() => setSelectedPattern(pattern)}
-                                        className={`group relative overflow-hidden rounded-2xl border ${
-                                            pattern.name === selectedPattern.name
-                                                ? "border-[#A1E2F8]"
-                                                : "border-white/10"
-                                        } bg-white/5 p-3 text-left transition hover:border-[#A1E2F8]/60`}
-                                    >
-                                        <div
-                                            className="h-24 w-full rounded-xl border border-white/10"
-                                            style={parseCSS(pattern.style, patternScale, patternColor1, patternColor2)}
-                                        />
-                                        <span className="mt-3 block text-sm font-medium text-white">
-                                            {pattern.name}
-                                        </span>
-                                    </button>
-                                ))}
+                        <div className="flex flex-1 flex-col gap-8">
+                            <div className="w-full rounded-3xl border border-[#A1E2F8]/20 bg-white/5 p-6 backdrop-blur-xl shadow-[0_25px_80px_-35px_rgba(192,230,244,0.55)]">
+                                <div className="mb-4 flex items-center justify-between text-sm uppercase tracking-[0.35em] text-[#A1E2F8]/70">
+                                    <span>Preview</span>
+                                    <span>{textStyles.fontSize}px</span>
+                                </div>
+                                <div className="overflow-hidden rounded-2xl border border-white/10 bg-black/40">
+                                    <BannerPreview
+                                        selectedPattern={selectedPattern}
+                                        patternColor1={patternColor1}
+                                        patternColor2={patternColor2}
+                                        patternScale={patternScale}
+                                        textContent={textContent}
+                                        textStyles={textStyles}
+                                        previewRef={previewRef}
+                                        onTextChange={setTextContent}
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="flex flex-col gap-6">
+                                <div className="rounded-3xl border border-[#A1E2F8]/10 bg-white/5 p-6 backdrop-blur-xl shadow-[0_20px_60px_-35px_rgba(192,230,244,0.45)]">
+                                    <h2 className="text-lg font-semibold text-white">Pattern auswählen</h2>
+                                    <p className="mt-2 text-sm text-white/60">
+                                        Feine Texturen für lebendige Banner. Justiere Farben und Skalierung, um deinen Look zu perfektionieren.
+                                    </p>
+                                    <div className="mt-6 max-h-[22rem] overflow-y-auto pr-2">
+                                        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                                            {patterns.map((pattern) => (
+                                                <button
+                                                    key={pattern.name}
+                                                    type="button"
+                                                    onClick={() => setSelectedPattern(pattern)}
+                                                    className={`group relative overflow-hidden rounded-2xl border ${
+                                                        pattern.name === selectedPattern.name
+                                                            ? "border-[#A1E2F8]"
+                                                            : "border-white/10"
+                                                    } bg-white/5 p-3 text-left transition hover:border-[#A1E2F8]/60`}
+                                                >
+                                                    <div
+                                                        className="h-24 w-full rounded-xl border border-white/10"
+                                                        style={parseCSS(pattern.style, patternScale, patternColor1, patternColor2)}
+                                                    />
+                                                    <span className="mt-3 block text-sm font-medium text-white">
+                                                        {pattern.name}
+                                                    </span>
+                                                </button>
+                                            ))}
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div className="rounded-3xl border border-[#A1E2F8]/15 bg-white/5 p-6 backdrop-blur-xl shadow-[0_25px_70px_-30px_rgba(192,230,244,0.45)]">
+                                    <h2 className="text-lg font-semibold text-white">Farben & Scale</h2>
+                                    <p className="mt-2 text-sm text-white/60">
+                                        Passe die Farben für deinen Pattern-Look an und justiere die Skalierung für mehr Dynamik.
+                                    </p>
+                                    <SettingsPanel
+                                        patternColor1={patternColor1}
+                                        setPatternColor1={setPatternColor1}
+                                        patternColor2={patternColor2}
+                                        setPatternColor2={setPatternColor2}
+                                        patternScale={patternScale}
+                                        setPatternScale={setPatternScale}
+                                        darkMode={darkMode}
+                                        visiblePicker={visiblePicker}
+                                        togglePicker={togglePicker}
+                                    />
+                                </div>
                             </div>
                         </div>
-                    </div>
-
-                    <div className="rounded-3xl border border-[#A1E2F8]/15 bg-white/5 p-6 backdrop-blur-xl shadow-[0_25px_70px_-30px_rgba(192,230,244,0.45)]">
-                        <h2 className="text-lg font-semibold text-white">Farben & Scale</h2>
-                        <p className="mt-2 text-sm text-white/60">
-                            Passe die Farben für deinen Pattern-Look an und justiere die Skalierung für mehr Dynamik.
-                        </p>
-                        <SettingsPanel
-                            patternColor1={patternColor1}
-                            setPatternColor1={setPatternColor1}
-                            patternColor2={patternColor2}
-                            setPatternColor2={setPatternColor2}
-                            patternScale={patternScale}
-                            setPatternScale={setPatternScale}
-                            darkMode={darkMode}
-                            visiblePicker={visiblePicker}
-                            togglePicker={togglePicker}
-                        />
                     </div>
                 </motion.section>
             </div>

--- a/src/components/Preview/BannerPreview.tsx
+++ b/src/components/Preview/BannerPreview.tsx
@@ -48,7 +48,7 @@ const BannerPreview: React.FC<BannerPreviewProps> = ({
                 ...parseCSS(selectedPattern.style, patternScale, patternColor1, patternColor2),
                 position: "relative",
                 width: "100%",
-                height: "400px", // Hier die Banner-Höhe anpassen
+                height: "320px", // Hier die Banner-Höhe anpassen
                 overflow: "hidden",
             }}
         >


### PR DESCRIPTION
## Summary
- tighten the creator workspace columns so the sidebar anchors on the left while the preview stretches the full width of the main column
- bound the pattern grid height to two rows with vertical scrolling to keep the section compact
- shrink the banner preview height for a less dominant overview while preserving editing controls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6118198448324af5942df4066c58c