### PR TITLE
Add sliding font options drawer on creator page

### DIFF
--- a/src/app/creator/page.tsx
+++ b/src/app/creator/page.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useRef, useState } from "react";
 import Link from "next/link";
-import { motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 
 import Sidebar from "@/components/Sidebar/Sidebar";
 import BannerPreview from "@/components/Preview/BannerPreview";
@@ -30,7 +30,7 @@ const CreatorPage = () => {
     const [patternColor2, setPatternColor2] = useState("#b3b3c4");
     const [patternScale, setPatternScale] = useState(14);
     const [visiblePicker, setVisiblePicker] = useState<string | null>(null);
-    const [isFontPanelOpen, setIsFontPanelOpen] = useState(true);
+    const [isFontPanelOpen, setIsFontPanelOpen] = useState(false);
 
     const previewRef = useRef<HTMLDivElement>(null);
     const darkMode = true;
@@ -129,111 +129,133 @@ const CreatorPage = () => {
                     initial={{ opacity: 0, y: 32 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ duration: 0.7 }}
-                    className="flex flex-col gap-8"
+                    className="relative flex flex-col gap-8"
                 >
-                    <div className="flex flex-col gap-8 xl:flex-row xl:items-start xl:gap-12">
-                        <div className="flex w-full flex-col gap-4 xl:sticky xl:top-24 xl:w-72 xl:self-start">
-                            <button
-                                type="button"
-                                aria-expanded={isFontPanelOpen}
-                                onClick={() => setIsFontPanelOpen((prev) => !prev)}
-                                className="flex items-center justify-between rounded-full border border-white/10 bg-white/5 px-5 py-3 text-sm font-medium tracking-[0.2em] uppercase text-white/70 transition hover:border-[#A1E2F8]/40 hover:text-white"
-                            >
-                                <span>Schriftoptionen</span>
-                                <span className="text-xs text-[#A1E2F8]">{isFontPanelOpen ? "Einklappen" : "Ausklappen"}</span>
-                            </button>
-                            {isFontPanelOpen && (
-                                <Sidebar
-                                    toggleStyle={toggleStyle}
-                                    changeFontSize={changeFontSize}
-                                    changeAlignment={changeAlignment}
-                                    currentFontSize={textStyles.fontSize}
-                                    changeTextColor={changeTextColor}
-                                    changeFontFamily={changeFontFamily}
-                                    noWrap={textStyles.noWrap}
-                                    toggleNoWrap={toggleNoWrap}
+                    <div className="flex justify-end">
+                        <button
+                            type="button"
+                            aria-expanded={isFontPanelOpen}
+                            onClick={() => setIsFontPanelOpen((prev) => !prev)}
+                            className="flex items-center justify-between gap-3 rounded-full border border-white/10 bg-white/5 px-5 py-3 text-sm font-medium tracking-[0.2em] uppercase text-white/70 transition hover:border-[#A1E2F8]/40 hover:text-white"
+                        >
+                            <span>Schriftoptionen</span>
+                            <span className="text-xs text-[#A1E2F8]">{isFontPanelOpen ? "Schließen" : "Öffnen"}</span>
+                        </button>
+                    </div>
+
+                    <div className="flex flex-col gap-8">
+                        <div className="w-full rounded-3xl border border-[#A1E2F8]/20 bg-white/5 p-6 backdrop-blur-xl shadow-[0_25px_80px_-35px_rgba(192,230,244,0.55)]">
+                            <div className="mb-4 flex items-center justify-between text-sm uppercase tracking-[0.35em] text-[#A1E2F8]/70">
+                                <span>Preview</span>
+                                <span>{textStyles.fontSize}px</span>
+                            </div>
+                            <div className="overflow-hidden rounded-2xl border border-white/10 bg-black/40">
+                                <BannerPreview
+                                    selectedPattern={selectedPattern}
+                                    patternColor1={patternColor1}
+                                    patternColor2={patternColor2}
+                                    patternScale={patternScale}
+                                    textContent={textContent}
+                                    textStyles={textStyles}
+                                    previewRef={previewRef}
+                                    onTextChange={setTextContent}
+                                />
+                            </div>
+                        </div>
+
+                        <div className="flex flex-col gap-6">
+                            <div className="rounded-3xl border border-[#A1E2F8]/10 bg-white/5 p-6 backdrop-blur-xl shadow-[0_20px_60px_-35px_rgba(192,230,244,0.45)]">
+                                <h2 className="text-lg font-semibold text-white">Pattern auswählen</h2>
+                                <p className="mt-2 text-sm text-white/60">
+                                    Feine Texturen für lebendige Banner. Justiere Farben und Skalierung, um deinen Look zu perfektionieren.
+                                </p>
+                                <div className="mt-6 max-h-[13rem] overflow-y-auto pr-2">
+                                    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                                        {patterns.map((pattern) => (
+                                            <button
+                                                key={pattern.name}
+                                                type="button"
+                                                onClick={() => setSelectedPattern(pattern)}
+                                                className={`group relative overflow-hidden rounded-2xl border ${
+                                                    pattern.name === selectedPattern.name
+                                                        ? "border-[#A1E2F8]"
+                                                        : "border-white/10"
+                                                } bg-white/5 p-3 text-left transition hover:border-[#A1E2F8]/60`}
+                                            >
+                                                <div
+                                                    className="h-24 w-full rounded-xl border border-white/10"
+                                                    style={parseCSS(pattern.style, patternScale, patternColor1, patternColor2)}
+                                                />
+                                                <span className="mt-3 block text-sm font-medium text-white">
+                                                    {pattern.name}
+                                                </span>
+                                            </button>
+                                        ))}
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div className="rounded-3xl border border-[#A1E2F8]/15 bg-white/5 p-6 backdrop-blur-xl shadow-[0_25px_70px_-30px_rgba(192,230,244,0.45)]">
+                                <h2 className="text-lg font-semibold text-white">Farben & Scale</h2>
+                                <p className="mt-2 text-sm text-white/60">
+                                    Passe die Farben für deinen Pattern-Look an und justiere die Skalierung für mehr Dynamik.
+                                </p>
+                                <SettingsPanel
+                                    patternColor1={patternColor1}
+                                    setPatternColor1={setPatternColor1}
+                                    patternColor2={patternColor2}
+                                    setPatternColor2={setPatternColor2}
+                                    patternScale={patternScale}
+                                    setPatternScale={setPatternScale}
                                     darkMode={darkMode}
                                     visiblePicker={visiblePicker}
                                     togglePicker={togglePicker}
-                                    patternScale={patternScale}
-                                    setPatternScale={setPatternScale}
-                                    onEmojiSelect={handleEmojiSelect}
                                 />
-                            )}
-                        </div>
-
-                        <div className="flex flex-1 flex-col gap-8">
-                            <div className="w-full rounded-3xl border border-[#A1E2F8]/20 bg-white/5 p-6 backdrop-blur-xl shadow-[0_25px_80px_-35px_rgba(192,230,244,0.55)]">
-                                <div className="mb-4 flex items-center justify-between text-sm uppercase tracking-[0.35em] text-[#A1E2F8]/70">
-                                    <span>Preview</span>
-                                    <span>{textStyles.fontSize}px</span>
-                                </div>
-                                <div className="overflow-hidden rounded-2xl border border-white/10 bg-black/40">
-                                    <BannerPreview
-                                        selectedPattern={selectedPattern}
-                                        patternColor1={patternColor1}
-                                        patternColor2={patternColor2}
-                                        patternScale={patternScale}
-                                        textContent={textContent}
-                                        textStyles={textStyles}
-                                        previewRef={previewRef}
-                                        onTextChange={setTextContent}
-                                    />
-                                </div>
-                            </div>
-
-                            <div className="flex flex-col gap-6">
-                                <div className="rounded-3xl border border-[#A1E2F8]/10 bg-white/5 p-6 backdrop-blur-xl shadow-[0_20px_60px_-35px_rgba(192,230,244,0.45)]">
-                                    <h2 className="text-lg font-semibold text-white">Pattern auswählen</h2>
-                                    <p className="mt-2 text-sm text-white/60">
-                                        Feine Texturen für lebendige Banner. Justiere Farben und Skalierung, um deinen Look zu perfektionieren.
-                                    </p>
-                                    <div className="mt-6 max-h-[13rem] overflow-y-auto pr-2">
-                                        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-                                            {patterns.map((pattern) => (
-                                                <button
-                                                    key={pattern.name}
-                                                    type="button"
-                                                    onClick={() => setSelectedPattern(pattern)}
-                                                    className={`group relative overflow-hidden rounded-2xl border ${
-                                                        pattern.name === selectedPattern.name
-                                                            ? "border-[#A1E2F8]"
-                                                            : "border-white/10"
-                                                    } bg-white/5 p-3 text-left transition hover:border-[#A1E2F8]/60`}
-                                                >
-                                                    <div
-                                                        className="h-24 w-full rounded-xl border border-white/10"
-                                                        style={parseCSS(pattern.style, patternScale, patternColor1, patternColor2)}
-                                                    />
-                                                    <span className="mt-3 block text-sm font-medium text-white">
-                                                        {pattern.name}
-                                                    </span>
-                                                </button>
-                                            ))}
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <div className="rounded-3xl border border-[#A1E2F8]/15 bg-white/5 p-6 backdrop-blur-xl shadow-[0_25px_70px_-30px_rgba(192,230,244,0.45)]">
-                                    <h2 className="text-lg font-semibold text-white">Farben & Scale</h2>
-                                    <p className="mt-2 text-sm text-white/60">
-                                        Passe die Farben für deinen Pattern-Look an und justiere die Skalierung für mehr Dynamik.
-                                    </p>
-                                    <SettingsPanel
-                                        patternColor1={patternColor1}
-                                        setPatternColor1={setPatternColor1}
-                                        patternColor2={patternColor2}
-                                        setPatternColor2={setPatternColor2}
-                                        patternScale={patternScale}
-                                        setPatternScale={setPatternScale}
-                                        darkMode={darkMode}
-                                        visiblePicker={visiblePicker}
-                                        togglePicker={togglePicker}
-                                    />
-                                </div>
                             </div>
                         </div>
                     </div>
+
+                    <AnimatePresence>
+                        {isFontPanelOpen && (
+                            <>
+                                <motion.button
+                                    type="button"
+                                    className="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm"
+                                    initial={{ opacity: 0 }}
+                                    animate={{ opacity: 1 }}
+                                    exit={{ opacity: 0 }}
+                                    aria-label="Schriftoptionen schließen"
+                                    onClick={() => setIsFontPanelOpen(false)}
+                                />
+                                <motion.aside
+                                    className="fixed inset-y-0 right-0 z-50 flex h-full w-full max-w-md p-6"
+                                    initial={{ x: "100%" }}
+                                    animate={{ x: 0 }}
+                                    exit={{ x: "100%" }}
+                                    transition={{ type: "spring", stiffness: 260, damping: 30 }}
+                                >
+                                    <div className="h-full w-full overflow-y-auto">
+                                        <Sidebar
+                                            toggleStyle={toggleStyle}
+                                            changeFontSize={changeFontSize}
+                                            changeAlignment={changeAlignment}
+                                            currentFontSize={textStyles.fontSize}
+                                            changeTextColor={changeTextColor}
+                                            changeFontFamily={changeFontFamily}
+                                            noWrap={textStyles.noWrap}
+                                            toggleNoWrap={toggleNoWrap}
+                                            darkMode={darkMode}
+                                            visiblePicker={visiblePicker}
+                                            togglePicker={togglePicker}
+                                            patternScale={patternScale}
+                                            setPatternScale={setPatternScale}
+                                            onEmojiSelect={handleEmojiSelect}
+                                        />
+                                    </div>
+                                </motion.aside>
+                            </>
+                        )}
+                    </AnimatePresence>
                 </motion.section>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- replace the static font sidebar with a toggle button that opens from the right edge
- allow the banner preview and pattern settings to use the full width when the drawer is closed
- add an animated backdrop so users can close the drawer by clicking outside

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e635aa6a008324aeaa01111593632b