### PR TITLE
Adjust creator layout and font controls

### DIFF
--- a/src/app/creator/page.tsx
+++ b/src/app/creator/page.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useRef, useState } from "react";
 import Link from "next/link";
-import { AnimatePresence, motion } from "framer-motion";
+import { motion } from "framer-motion";
 
 import Sidebar from "@/components/Sidebar/Sidebar";
 import BannerPreview from "@/components/Preview/BannerPreview";
@@ -30,8 +30,6 @@ const CreatorPage = () => {
     const [patternColor2, setPatternColor2] = useState("#b3b3c4");
     const [patternScale, setPatternScale] = useState(14);
     const [visiblePicker, setVisiblePicker] = useState<string | null>(null);
-    const [isFontPanelOpen, setIsFontPanelOpen] = useState(false);
-
     const previewRef = useRef<HTMLDivElement>(null);
     const darkMode = true;
 
@@ -131,132 +129,94 @@ const CreatorPage = () => {
                     transition={{ duration: 0.7 }}
                     className="relative flex flex-col gap-8"
                 >
-                    <div className="flex justify-start">
-                        <button
-                            type="button"
-                            aria-expanded={isFontPanelOpen}
-                            onClick={() => setIsFontPanelOpen((prev) => !prev)}
-                            className="flex items-center justify-between gap-3 rounded-full border border-white/10 bg-white/5 px-5 py-3 text-sm font-medium tracking-[0.2em] uppercase text-white/70 transition hover:border-[#A1E2F8]/40 hover:text-white"
-                        >
-                            <span>Schriftoptionen</span>
-                            <span className="text-xs text-[#A1E2F8]">{isFontPanelOpen ? "Schließen" : "Öffnen"}</span>
-                        </button>
-                    </div>
-
-                    <div className="flex flex-col gap-8">
-                        <div className="w-full rounded-3xl border border-[#A1E2F8]/20 bg-white/5 p-6 backdrop-blur-xl shadow-[0_25px_80px_-35px_rgba(192,230,244,0.55)]">
-                            <div className="mb-4 flex items-center justify-between text-sm uppercase tracking-[0.35em] text-[#A1E2F8]/70">
-                                <span>Preview</span>
-                                <span>{textStyles.fontSize}px</span>
-                            </div>
-                            <div className="overflow-hidden rounded-2xl border border-white/10 bg-black/40">
-                                <BannerPreview
-                                    selectedPattern={selectedPattern}
-                                    patternColor1={patternColor1}
-                                    patternColor2={patternColor2}
-                                    patternScale={patternScale}
-                                    textContent={textContent}
-                                    textStyles={textStyles}
-                                    previewRef={previewRef}
-                                    onTextChange={setTextContent}
-                                />
-                            </div>
+                    <div className="relative flex flex-col gap-8 xl:flex-row xl:items-stretch xl:gap-10">
+                        <div className="xl:w-[320px] xl:flex-shrink-0">
+                            <Sidebar
+                                toggleStyle={toggleStyle}
+                                changeFontSize={changeFontSize}
+                                changeAlignment={changeAlignment}
+                                currentFontSize={textStyles.fontSize}
+                                changeTextColor={changeTextColor}
+                                changeFontFamily={changeFontFamily}
+                                noWrap={textStyles.noWrap}
+                                toggleNoWrap={toggleNoWrap}
+                                onEmojiSelect={handleEmojiSelect}
+                                textStyles={textStyles}
+                            />
                         </div>
 
-                        <div className="flex flex-col gap-6">
-                            <div className="rounded-3xl border border-[#A1E2F8]/10 bg-white/5 p-6 backdrop-blur-xl shadow-[0_20px_60px_-35px_rgba(192,230,244,0.45)]">
-                                <h2 className="text-lg font-semibold text-white">Pattern auswählen</h2>
-                                <p className="mt-2 text-sm text-white/60">
-                                    Feine Texturen für lebendige Banner. Justiere Farben und Skalierung, um deinen Look zu perfektionieren.
-                                </p>
-                                <div className="mt-6 max-h-[13rem] overflow-y-auto pr-2">
-                                    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-                                        {patterns.map((pattern) => (
-                                            <button
-                                                key={pattern.name}
-                                                type="button"
-                                                onClick={() => setSelectedPattern(pattern)}
-                                                className={`group relative overflow-hidden rounded-2xl border ${
-                                                    pattern.name === selectedPattern.name
-                                                        ? "border-[#A1E2F8]"
-                                                        : "border-white/10"
-                                                } bg-white/5 p-2.5 text-left transition hover:border-[#A1E2F8]/60`}
-                                            >
-                                                <div
-                                                    className="h-20 w-full rounded-lg border border-white/10"
-                                                    style={parseCSS(pattern.style, 14, patternColor1, patternColor2)}
-                                                />
-                                                <span className="mt-3 block text-sm font-medium text-white">
-                                                    {pattern.name}
-                                                </span>
-                                            </button>
-                                        ))}
-                                    </div>
+                        <div className="flex flex-1 flex-col gap-8">
+                            <div className="w-full rounded-3xl border border-[#A1E2F8]/20 bg-white/5 p-6 backdrop-blur-xl shadow-[0_25px_80px_-35px_rgba(192,230,244,0.55)]">
+                                <div className="mb-4 flex items-center justify-between text-sm uppercase tracking-[0.35em] text-[#A1E2F8]/70">
+                                    <span>Preview</span>
+                                    <span>{textStyles.fontSize}px</span>
+                                </div>
+                                <div className="overflow-hidden rounded-2xl border border-white/10 bg-black/40">
+                                    <BannerPreview
+                                        selectedPattern={selectedPattern}
+                                        patternColor1={patternColor1}
+                                        patternColor2={patternColor2}
+                                        patternScale={patternScale}
+                                        textContent={textContent}
+                                        textStyles={textStyles}
+                                        previewRef={previewRef}
+                                        onTextChange={setTextContent}
+                                    />
                                 </div>
                             </div>
 
-                            <div className="rounded-3xl border border-[#A1E2F8]/15 bg-white/5 p-6 backdrop-blur-xl shadow-[0_25px_70px_-30px_rgba(192,230,244,0.45)]">
-                                <h2 className="text-lg font-semibold text-white">Farben & Scale</h2>
-                                <p className="mt-2 text-sm text-white/60">
-                                    Passe die Farben für deinen Pattern-Look an und justiere die Skalierung für mehr Dynamik.
-                                </p>
-                                <SettingsPanel
-                                    patternColor1={patternColor1}
-                                    setPatternColor1={setPatternColor1}
-                                    patternColor2={patternColor2}
-                                    setPatternColor2={setPatternColor2}
-                                    patternScale={patternScale}
-                                    setPatternScale={setPatternScale}
-                                    darkMode={darkMode}
-                                    visiblePicker={visiblePicker}
-                                    togglePicker={togglePicker}
-                                />
+                            <div className="flex flex-col gap-6">
+                                <div className="rounded-3xl border border-[#A1E2F8]/10 bg-white/5 p-6 backdrop-blur-xl shadow-[0_20px_60px_-35px_rgba(192,230,244,0.45)]">
+                                    <h2 className="text-lg font-semibold text-white">Pattern auswählen</h2>
+                                    <p className="mt-2 text-sm text-white/60">
+                                        Feine Texturen für lebendige Banner. Justiere Farben und Skalierung, um deinen Look zu perfektionieren.
+                                    </p>
+                                    <div className="mt-6 max-h-[13rem] overflow-y-auto pr-2">
+                                        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                                            {patterns.map((pattern) => (
+                                                <button
+                                                    key={pattern.name}
+                                                    type="button"
+                                                    onClick={() => setSelectedPattern(pattern)}
+                                                    className={`group relative overflow-hidden rounded-2xl border ${
+                                                        pattern.name === selectedPattern.name
+                                                            ? "border-[#A1E2F8]"
+                                                            : "border-white/10"
+                                                    } bg-white/5 p-2.5 text-left transition hover:border-[#A1E2F8]/60`}
+                                                >
+                                                    <div
+                                                        className="h-20 w-full rounded-lg border border-white/10"
+                                                        style={parseCSS(pattern.style, 14, patternColor1, patternColor2)}
+                                                    />
+                                                    <span className="mt-3 block text-sm font-medium text-white">
+                                                        {pattern.name}
+                                                    </span>
+                                                </button>
+                                            ))}
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div className="rounded-3xl border border-[#A1E2F8]/15 bg-white/5 p-6 backdrop-blur-xl shadow-[0_25px_70px_-30px_rgba(192,230,244,0.45)]">
+                                    <h2 className="text-lg font-semibold text-white">Farben & Scale</h2>
+                                    <p className="mt-2 text-sm text-white/60">
+                                        Passe die Farben für deinen Pattern-Look an und justiere die Skalierung für mehr Dynamik.
+                                    </p>
+                                    <SettingsPanel
+                                        patternColor1={patternColor1}
+                                        setPatternColor1={setPatternColor1}
+                                        patternColor2={patternColor2}
+                                        setPatternColor2={setPatternColor2}
+                                        patternScale={patternScale}
+                                        setPatternScale={setPatternScale}
+                                        darkMode={darkMode}
+                                        visiblePicker={visiblePicker}
+                                        togglePicker={togglePicker}
+                                    />
+                                </div>
                             </div>
                         </div>
                     </div>
-
-                    <AnimatePresence>
-                        {isFontPanelOpen && (
-                            <>
-                                <motion.button
-                                    type="button"
-                                    className="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm"
-                                    initial={{ opacity: 0 }}
-                                    animate={{ opacity: 1 }}
-                                    exit={{ opacity: 0 }}
-                                    aria-label="Schriftoptionen schließen"
-                                    onClick={() => setIsFontPanelOpen(false)}
-                                />
-                                <motion.aside
-                                    className="fixed inset-y-0 left-0 z-50 flex h-full w-full max-w-md p-6"
-                                    initial={{ x: "-100%" }}
-                                    animate={{ x: 0 }}
-                                    exit={{ x: "-100%" }}
-                                    transition={{ type: "spring", stiffness: 260, damping: 30 }}
-                                >
-                                    <div className="h-full w-full overflow-y-auto">
-                                        <Sidebar
-                                            toggleStyle={toggleStyle}
-                                            changeFontSize={changeFontSize}
-                                            changeAlignment={changeAlignment}
-                                            currentFontSize={textStyles.fontSize}
-                                            changeTextColor={changeTextColor}
-                                            changeFontFamily={changeFontFamily}
-                                            noWrap={textStyles.noWrap}
-                                            toggleNoWrap={toggleNoWrap}
-                                            darkMode={darkMode}
-                                            visiblePicker={visiblePicker}
-                                            togglePicker={togglePicker}
-                                            patternScale={patternScale}
-                                            setPatternScale={setPatternScale}
-                                            onEmojiSelect={handleEmojiSelect}
-                                            textStyles={textStyles}
-                                        />
-                                    </div>
-                                </motion.aside>
-                            </>
-                        )}
-                    </AnimatePresence>
                 </motion.section>
             </div>
         </div>

--- a/src/app/creator/page.tsx
+++ b/src/app/creator/page.tsx
@@ -131,7 +131,7 @@ const CreatorPage = () => {
                     transition={{ duration: 0.7 }}
                     className="relative flex flex-col gap-8"
                 >
-                    <div className="flex justify-end">
+                    <div className="flex justify-start">
                         <button
                             type="button"
                             aria-expanded={isFontPanelOpen}
@@ -228,10 +228,10 @@ const CreatorPage = () => {
                                     onClick={() => setIsFontPanelOpen(false)}
                                 />
                                 <motion.aside
-                                    className="fixed inset-y-0 right-0 z-50 flex h-full w-full max-w-md p-6"
-                                    initial={{ x: "100%" }}
+                                    className="fixed inset-y-0 left-0 z-50 flex h-full w-full max-w-md p-6"
+                                    initial={{ x: "-100%" }}
                                     animate={{ x: 0 }}
-                                    exit={{ x: "100%" }}
+                                    exit={{ x: "-100%" }}
                                     transition={{ type: "spring", stiffness: 260, damping: 30 }}
                                 >
                                     <div className="h-full w-full overflow-y-auto">

--- a/src/app/creator/page.tsx
+++ b/src/app/creator/page.tsx
@@ -180,11 +180,11 @@ const CreatorPage = () => {
                                                     pattern.name === selectedPattern.name
                                                         ? "border-[#A1E2F8]"
                                                         : "border-white/10"
-                                                } bg-white/5 p-3 text-left transition hover:border-[#A1E2F8]/60`}
+                                                } bg-white/5 p-2.5 text-left transition hover:border-[#A1E2F8]/60`}
                                             >
                                                 <div
-                                                    className="h-24 w-full rounded-xl border border-white/10"
-                                                    style={parseCSS(pattern.style, patternScale, patternColor1, patternColor2)}
+                                                    className="h-20 w-full rounded-lg border border-white/10"
+                                                    style={parseCSS(pattern.style, 14, patternColor1, patternColor2)}
                                                 />
                                                 <span className="mt-3 block text-sm font-medium text-white">
                                                     {pattern.name}
@@ -250,6 +250,7 @@ const CreatorPage = () => {
                                             patternScale={patternScale}
                                             setPatternScale={setPatternScale}
                                             onEmojiSelect={handleEmojiSelect}
+                                            textStyles={textStyles}
                                         />
                                     </div>
                                 </motion.aside>

--- a/src/components/Sidebar/ColorPicker.tsx
+++ b/src/components/Sidebar/ColorPicker.tsx
@@ -2,9 +2,9 @@
 "use client";
 
 import React from "react";
-import ColorPicker from 'react-best-gradient-color-picker';
+import ColorPicker from "react-best-gradient-color-picker";
 
-import {colors} from "@/constants/colors";
+import { colors } from "@/constants/colors";
 
 interface ColorPickerProps {
     color: string;
@@ -32,60 +32,63 @@ const ColorPickerComponent: React.FC<ColorPickerProps> = ({
         <div className="relative">
             <button
                 onClick={togglePicker}
-                className="w-10 h-10 rounded-full ring-2 ring-white/10"
+                className="h-10 w-10 rounded-full ring-2 ring-white/10 transition hover:ring-[#A1E2F8]/60"
                 style={{ backgroundColor: color }}
                 aria-label="Toggle Color Picker"
             />
             {isVisible && (
                 <div
-                    className="absolute top-12 left-0 bg-gray-50 dark:bg-gray-800 rounded-md shadow-lg border-2 ring-1 ring-white/10 p-4 transition-opacity duration-300 z-50"
+                    className="absolute bottom-[calc(100%+0.75rem)] left-1/2 z-50 w-[18rem] -translate-x-1/2 rounded-2xl border border-white/10 bg-zinc-900/95 p-4 shadow-[0_25px_70px_-35px_rgba(192,230,244,0.6)] backdrop-blur"
                 >
                     <ColorPicker
                         style={{
                             body: {
-                                background: 'rgb(32, 32, 32)',
+                                background: "transparent",
+                                boxShadow: "none",
                             },
                             rbgcpInputLabel: {
-                                color: 'rgb(212, 212, 212)',
+                                color: "rgb(225, 233, 240)",
                             },
                             rbgcpControlBtnWrapper: {
-                                background: 'rgb(54, 54, 54)',
+                                background: "rgba(255,255,255,0.04)",
+                                borderRadius: "12px",
                             },
                             rbgcpInput: {
-                                border: 'none',
-                                color: 'white',
-                                background: 'rgb(54, 54, 54)',
+                                border: "none",
+                                color: "white",
+                                background: "rgba(255,255,255,0.06)",
                             },
                             rbgcpControlBtn: {
-                                color: 'rgb(212, 212, 212)',
+                                color: "rgb(225, 233, 240)",
                             },
                             rbgcpControlIcon: {
-                                stroke: 'rgb(212, 212, 212)',
+                                stroke: "rgb(225, 233, 240)",
                             },
                             rbgcpControlIcon2: {
-                                fill: 'rgb(212, 212, 212)',
+                                fill: "rgb(225, 233, 240)",
                             },
                             rbgcpControlInput: {
-                                color: 'white',
+                                color: "white",
                             },
                             rbgcpControlBtnSelected: {
-                                background: 'black',
-                                color: '#568cf5',
+                                background: "rgba(161, 226, 248, 0.18)",
+                                color: "#A1E2F8",
                             },
                             rbgcpDegreeIcon: {
-                                color: 'rgb(212, 212, 212)',
+                                color: "rgb(225, 233, 240)",
                             },
                             rbgcpColorModelDropdown: {
-                                background: 'rgb(32, 32, 32)',
+                                background: "rgba(8,8,12,0.85)",
+                                borderRadius: "12px",
                             },
                             rbgcpComparibleLabel: {
-                                color: 'rgb(212, 212, 212)',
-                            }
+                                color: "rgb(225, 233, 240)",
+                            },
                         }}
                         value={color}
                         onChange={(newColor) => setColor(rgbaToHex(newColor))}
-                        width={300}
-                        height={150}
+                        width={260}
+                        height={180}
                         hideGradientType
                         hidePresets={false}
                         disableLightMode={!darkMode}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -14,11 +14,6 @@ interface SidebarProps {
     changeFontFamily: (f: string) => void;
     noWrap: boolean;
     toggleNoWrap: () => void;
-    darkMode: boolean;
-    visiblePicker: string | null;
-    togglePicker: (id: string) => void;
-    patternScale: number;
-    setPatternScale: (s: number) => void;
     onEmojiSelect: (e: string) => void;
     textStyles: TextStyles;
 }
@@ -43,7 +38,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 
     return (
         <aside
-            className="relative flex w-full flex-col gap-6 rounded-[26px] border border-white/10 bg-black/40 p-6 backdrop-blur-xl shadow-[0_20px_60px_-30px_rgba(192,230,244,0.55)] transition duration-150"
+            className="relative flex h-full w-full flex-col gap-6 rounded-[26px] border border-white/10 bg-black/40 p-6 backdrop-blur-xl shadow-[0_20px_60px_-30px_rgba(192,230,244,0.55)] transition duration-150"
         >
             {/* Typografie-Kontrollen */}
             <FontControls

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import EmojiPicker from "@/components/Sidebar/EmojiPicker";
 import { FontControls } from "../organisms";
+import { TextStyles } from "@/types";
 
 interface SidebarProps {
     toggleStyle: (s: "bold" | "italic" | "underline" | "strikethrough") => void;
@@ -19,6 +20,7 @@ interface SidebarProps {
     patternScale: number;
     setPatternScale: (s: number) => void;
     onEmojiSelect: (e: string) => void;
+    textStyles: TextStyles;
 }
 
 const Sidebar: React.FC<SidebarProps> = ({
@@ -31,6 +33,7 @@ const Sidebar: React.FC<SidebarProps> = ({
                                              noWrap,
                                              toggleNoWrap,
                                              onEmojiSelect,
+                                             textStyles,
                                          }) => {
     const [showEmojiPicker, setShowEmojiPicker] = useState(false);
 
@@ -52,6 +55,7 @@ const Sidebar: React.FC<SidebarProps> = ({
                 changeFontFamily={changeFontFamily}
                 noWrap={noWrap}
                 toggleNoWrap={toggleNoWrap}
+                textStyles={textStyles}
             />
 
             {/* Emoji-Toggle & Picker ------------------------------------------- */}

--- a/src/components/atoms/NoWrapToggle.tsx
+++ b/src/components/atoms/NoWrapToggle.tsx
@@ -1,5 +1,5 @@
 import { MdWrapText } from "react-icons/md";
-import {GlassButton} from "@/components/atoms/GlassButton";
+import { GlassButton } from "@/components/atoms/GlassButton";
 
 interface Props {
     active: boolean;
@@ -7,13 +7,9 @@ interface Props {
 }
 
 export const NoWrapToggle: React.FC<Props> = ({ active, onToggle }) => (
-    <div className="flex gap-x-14 ml-4 mb-12 mt-8">
-        <GlassButton
-            active={active}
-            onClick={onToggle}
-            aria-label="Toggle no‑wrap"
-        >
-            <MdWrapText />
+    <div className="flex">
+        <GlassButton active={active} onClick={onToggle} aria-label="Zeilenumbruch umschalten" padding="10px 12px">
+            <MdWrapText className="text-lg" />
         </GlassButton>
     </div>
 );

--- a/src/components/molecules/AlignmentControls.tsx
+++ b/src/components/molecules/AlignmentControls.tsx
@@ -7,16 +7,21 @@ import {
     MdFormatAlignJustify,
 } from "react-icons/md";
 import { GlassButton } from "../atoms";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 type Align = "left" | "center" | "right" | "justify";
 
 interface AlignmentControlsProps {
     onChange: (v: Align) => void;
+    value: Align;
 }
 
-export const AlignmentControls: React.FC<AlignmentControlsProps> = ({ onChange }) => {
-    const [local, setLocal] = useState<Align>("left");
+export const AlignmentControls: React.FC<AlignmentControlsProps> = ({ onChange, value }) => {
+    const [local, setLocal] = useState<Align>(value);
+
+    useEffect(() => {
+        setLocal(value);
+    }, [value]);
 
     const handle = (v: Align) => {
         setLocal(v);
@@ -24,11 +29,19 @@ export const AlignmentControls: React.FC<AlignmentControlsProps> = ({ onChange }
     };
 
     return (
-        <div className="flex ml-4 mb-12 mt-8" style={{columnGap: "4.3rem"}}>
-            <GlassButton active={local === "left"}   onClick={() => handle("left")}   aria-label="Links"><MdAlignHorizontalLeft /></GlassButton>
-            <GlassButton active={local === "center"} onClick={() => handle("center")} aria-label="Zentriert"><MdAlignHorizontalCenter /></GlassButton>
-            <GlassButton active={local === "right"}  onClick={() => handle("right")}  aria-label="Rechts"><MdAlignHorizontalRight /></GlassButton>
-            <GlassButton active={local === "justify"}onClick={() => handle("justify")}aria-label="Blocksatz"><MdFormatAlignJustify /></GlassButton>
+        <div className="flex flex-wrap gap-3">
+            <GlassButton active={local === "left"} onClick={() => handle("left")} aria-label="Links" padding="10px 12px">
+                <MdAlignHorizontalLeft />
+            </GlassButton>
+            <GlassButton active={local === "center"} onClick={() => handle("center")} aria-label="Zentriert" padding="10px 12px">
+                <MdAlignHorizontalCenter />
+            </GlassButton>
+            <GlassButton active={local === "right"} onClick={() => handle("right")} aria-label="Rechts" padding="10px 12px">
+                <MdAlignHorizontalRight />
+            </GlassButton>
+            <GlassButton active={local === "justify"} onClick={() => handle("justify")} aria-label="Blocksatz" padding="10px 12px">
+                <MdFormatAlignJustify />
+            </GlassButton>
         </div>
     );
 };

--- a/src/components/molecules/AlignmentControls.tsx
+++ b/src/components/molecules/AlignmentControls.tsx
@@ -29,18 +29,18 @@ export const AlignmentControls: React.FC<AlignmentControlsProps> = ({ onChange, 
     };
 
     return (
-        <div className="flex flex-wrap gap-3">
-            <GlassButton active={local === "left"} onClick={() => handle("left")} aria-label="Links" padding="10px 12px">
-                <MdAlignHorizontalLeft />
+        <div className="flex flex-wrap gap-x-16 gap-y-8 pl-4 pt-6 pb-6">
+            <GlassButton active={local === "left"} onClick={() => handle("left")} aria-label="Links" padding="14px 18px">
+                <MdAlignHorizontalLeft className="text-xl" />
             </GlassButton>
-            <GlassButton active={local === "center"} onClick={() => handle("center")} aria-label="Zentriert" padding="10px 12px">
-                <MdAlignHorizontalCenter />
+            <GlassButton active={local === "center"} onClick={() => handle("center")} aria-label="Zentriert" padding="14px 18px">
+                <MdAlignHorizontalCenter className="text-xl" />
             </GlassButton>
-            <GlassButton active={local === "right"} onClick={() => handle("right")} aria-label="Rechts" padding="10px 12px">
-                <MdAlignHorizontalRight />
+            <GlassButton active={local === "right"} onClick={() => handle("right")} aria-label="Rechts" padding="14px 18px">
+                <MdAlignHorizontalRight className="text-xl" />
             </GlassButton>
-            <GlassButton active={local === "justify"} onClick={() => handle("justify")} aria-label="Blocksatz" padding="10px 12px">
-                <MdFormatAlignJustify />
+            <GlassButton active={local === "justify"} onClick={() => handle("justify")} aria-label="Blocksatz" padding="14px 18px">
+                <MdFormatAlignJustify className="text-xl" />
             </GlassButton>
         </div>
     );

--- a/src/components/molecules/ColorPalettePicker.tsx
+++ b/src/components/molecules/ColorPalettePicker.tsx
@@ -3,12 +3,13 @@ import { ColorSwatch } from "../atoms";
 interface Props {
     colors: string[];
     onChange: (c: string) => void;
+    selectedColor?: string;
 }
 
-export const ColorPalettePicker: React.FC<Props> = ({ colors, onChange }) => (
+export const ColorPalettePicker: React.FC<Props> = ({ colors, onChange, selectedColor }) => (
     <div className="flex flex-wrap gap-x-3 gap-y-3">
         {colors.map((c) => (
-            <ColorSwatch key={c} color={c} onClick={() => onChange(c)} />
+            <ColorSwatch key={c} color={c} onClick={() => onChange(c)} selected={selectedColor === c} />
         ))}
     </div>
 );

--- a/src/components/molecules/FontDropdown.tsx
+++ b/src/components/molecules/FontDropdown.tsx
@@ -25,23 +25,32 @@ export const FontDropdown: React.FC<FontDropdownProps> = ({
             {/* Trigger‑Button */}
             <button
                 type="button"
-                className="w-full p-2 rounded-md bg-zinc-700 text-left"
+                className="flex w-full items-center justify-between rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-left text-sm text-white/80 transition hover:border-[#A1E2F8]/40 hover:text-white"
                 onClick={() => setIsOpen((prev) => !prev)}
                 style={{ fontFamily: selectedFontFamily }}
             >
-                {selectedFontFamily || "Select a Font"}
+                <span>
+                    {fonts.find((font) => font.style === selectedFontFamily)?.name || selectedFontFamily || "Schrift auswählen"}
+                </span>
+                <svg
+                    className={`h-4 w-4 transition-transform ${isOpen ? "rotate-180" : ""}`}
+                    viewBox="0 0 20 20"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                >
+                    <path d="M5 7.5L10 12.5L15 7.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                </svg>
             </button>
 
             {/* Dropdown */}
             {isOpen && (
                 <div
-                    className="absolute z-10 mt-1 w-full bg-zinc-700 rounded-md shadow-lg overflow-y-auto"
-                    style={{ maxHeight: 200 }}
+                    className="absolute z-10 mt-2 max-h-60 w-full overflow-y-auto rounded-xl border border-white/10 bg-zinc-900/95 p-1 shadow-[0_20px_60px_-30px_rgba(192,230,244,0.6)] backdrop-blur"
                 >
                     {fonts.map((font) => (
                         <div
                             key={font.name}
-                            className={`p-2 cursor-pointer hover:bg-zinc-600 ${font.className}`}
+                            className={`cursor-pointer rounded-lg px-3 py-2 text-sm text-white/80 transition hover:bg-white/10 hover:text-white ${font.className}`}
                             onClick={() => {
                                 onFontChange(font.style); // gibt die CSS‑font-family zurück
                                 setIsOpen(false);

--- a/src/components/molecules/FontSizeControls.tsx
+++ b/src/components/molecules/FontSizeControls.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { GlassButton } from "../atoms";
 
 interface Props {
@@ -13,30 +13,37 @@ const PRESET = [16, 20, 24, 32, 46, 64, 72, 96, 128, 144, 192, 256];
 export const FontSizeControls: React.FC<Props> = ({ value, onChange }) => {
     const [local, setLocal] = useState(value);
 
+    useEffect(() => {
+        setLocal(value);
+    }, [value]);
+
     const apply = (n: number) => {
         setLocal(n);
         onChange(n);
     };
 
     return (
-        <>
-            <div className="flex flex-wrap gap-x-16 gap-y-14 ml-6 mb-12 mt-8">
+        <div className="space-y-4">
+            <div className="grid grid-cols-4 gap-2 md:grid-cols-6">
                 {PRESET.map((n) => (
-                    <GlassButton key={n} active={local === n} onClick={() => apply(n)} isText={true} padding={"7px 7px"}>
+                    <GlassButton key={n} active={local === n} onClick={() => apply(n)} isText padding="8px 8px">
                         {n}
                     </GlassButton>
                 ))}
             </div>
 
-            <input
-                type="range"
-                min={16}
-                max={256}
-                step={1}
-                value={local}
-                onChange={(e) => apply(+e.target.value)}
-                className="w-full accent-indigo-500"
-            />
-        </>
+            <div className="flex flex-col gap-2">
+                <input
+                    type="range"
+                    min={16}
+                    max={256}
+                    step={1}
+                    value={local}
+                    onChange={(e) => apply(+e.target.value)}
+                    className="accent-[#A1E2F8]"
+                />
+                <span className="text-xs uppercase tracking-[0.2em] text-white/60">{local}px</span>
+            </div>
+        </div>
     );
 };

--- a/src/components/molecules/FontSizeControls.tsx
+++ b/src/components/molecules/FontSizeControls.tsx
@@ -23,16 +23,16 @@ export const FontSizeControls: React.FC<Props> = ({ value, onChange }) => {
     };
 
     return (
-        <div className="space-y-4">
-            <div className="grid grid-cols-4 gap-2 md:grid-cols-6">
+        <div className="space-y-6">
+            <div className="flex flex-wrap gap-x-16 gap-y-10 pl-6 pt-6 pb-6">
                 {PRESET.map((n) => (
-                    <GlassButton key={n} active={local === n} onClick={() => apply(n)} isText padding="8px 8px">
+                    <GlassButton key={n} active={local === n} onClick={() => apply(n)} isText padding="10px 14px">
                         {n}
                     </GlassButton>
                 ))}
             </div>
 
-            <div className="flex flex-col gap-2">
+            <div className="flex flex-col gap-3 px-2">
                 <input
                     type="range"
                     min={16}
@@ -42,7 +42,7 @@ export const FontSizeControls: React.FC<Props> = ({ value, onChange }) => {
                     onChange={(e) => apply(+e.target.value)}
                     className="accent-[#A1E2F8]"
                 />
-                <span className="text-xs uppercase tracking-[0.2em] text-white/60">{local}px</span>
+                <span className="text-xs uppercase tracking-[0.3em] text-white/60">{local}px</span>
             </div>
         </div>
     );

--- a/src/components/molecules/FontStyleControls.tsx
+++ b/src/components/molecules/FontStyleControls.tsx
@@ -13,28 +13,28 @@ export const FontStyleControls: React.FC<Props> = ({ value, toggleStyle }) => {
     const isActive = (s: Style) => value.includes(s);
 
     return (
-        <div className="flex flex-wrap gap-3">
-            <GlassButton active={isActive("bold")} onClick={() => toggleStyle("bold")} aria-label="Fett" padding="10px 12px">
-                <MdFormatBold className="text-lg" />
+        <div className="flex flex-wrap gap-x-16 gap-y-8 pl-4 pt-6 pb-6">
+            <GlassButton active={isActive("bold")} onClick={() => toggleStyle("bold")} aria-label="Fett" padding="14px 18px">
+                <MdFormatBold className="text-xl" />
             </GlassButton>
-            <GlassButton active={isActive("italic")} onClick={() => toggleStyle("italic")} aria-label="Kursiv" padding="10px 12px">
-                <MdFormatItalic className="text-lg" />
+            <GlassButton active={isActive("italic")} onClick={() => toggleStyle("italic")} aria-label="Kursiv" padding="14px 18px">
+                <MdFormatItalic className="text-xl" />
             </GlassButton>
             <GlassButton
                 active={isActive("underline")}
                 onClick={() => toggleStyle("underline")}
                 aria-label="Unterstrichen"
-                padding="10px 12px"
+                padding="14px 18px"
             >
-                <MdFormatUnderlined className="text-lg" />
+                <MdFormatUnderlined className="text-xl" />
             </GlassButton>
             <GlassButton
                 active={isActive("strikethrough")}
                 onClick={() => toggleStyle("strikethrough")}
                 aria-label="Durchgestrichen"
-                padding="10px 12px"
+                padding="14px 18px"
             >
-                <MdStrikethroughS className="text-lg" />
+                <MdStrikethroughS className="text-xl" />
             </GlassButton>
         </div>
     );

--- a/src/components/molecules/FontStyleControls.tsx
+++ b/src/components/molecules/FontStyleControls.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { MdFormatBold, MdFormatItalic, MdFormatUnderlined, MdStrikethroughS }
-    from "react-icons/md";
-import {GlassButton} from "../atoms";
+import { MdFormatBold, MdFormatItalic, MdFormatUnderlined, MdStrikethroughS } from "react-icons/md";
+import { GlassButton } from "../atoms";
 import { Style } from "@/types/Style";
 
 interface Props {
@@ -14,11 +13,29 @@ export const FontStyleControls: React.FC<Props> = ({ value, toggleStyle }) => {
     const isActive = (s: Style) => value.includes(s);
 
     return (
-        <div className="flex ml-4 mb-12 mt-8" style={{columnGap: "4.3rem"}}>
-            <GlassButton active={isActive("bold")}        onClick={() => toggleStyle("bold")}        aria-label="Fett">          <MdFormatBold className="text-xl" />        </GlassButton>
-            <GlassButton active={isActive("italic")}      onClick={() => toggleStyle("italic")}      aria-label="Kursiv">        <MdFormatItalic className="text-xl" />      </GlassButton>
-            <GlassButton active={isActive("underline")}   onClick={() => toggleStyle("underline")}   aria-label="Unterstrichen"> <MdFormatUnderlined className="text-xl" />   </GlassButton>
-            <GlassButton active={isActive("strikethrough")} onClick={() => toggleStyle("strikethrough")} aria-label="Durchgestrichen"> <MdStrikethroughS className="text-xl" /> </GlassButton>
+        <div className="flex flex-wrap gap-3">
+            <GlassButton active={isActive("bold")} onClick={() => toggleStyle("bold")} aria-label="Fett" padding="10px 12px">
+                <MdFormatBold className="text-lg" />
+            </GlassButton>
+            <GlassButton active={isActive("italic")} onClick={() => toggleStyle("italic")} aria-label="Kursiv" padding="10px 12px">
+                <MdFormatItalic className="text-lg" />
+            </GlassButton>
+            <GlassButton
+                active={isActive("underline")}
+                onClick={() => toggleStyle("underline")}
+                aria-label="Unterstrichen"
+                padding="10px 12px"
+            >
+                <MdFormatUnderlined className="text-lg" />
+            </GlassButton>
+            <GlassButton
+                active={isActive("strikethrough")}
+                onClick={() => toggleStyle("strikethrough")}
+                aria-label="Durchgestrichen"
+                padding="10px 12px"
+            >
+                <MdStrikethroughS className="text-lg" />
+            </GlassButton>
         </div>
     );
 };

--- a/src/components/organisms/FontControls.tsx
+++ b/src/components/organisms/FontControls.tsx
@@ -1,125 +1,188 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
-    Roboto, Open_Sans, Lato, Montserrat, Poppins, Raleway, Playfair_Display,
-    Merriweather, Ubuntu, Dancing_Script, Pacifico, Cinzel, Rubik, Oswald,
-    Noto_Serif, Lobster
+    Roboto,
+    Open_Sans,
+    Lato,
+    Montserrat,
+    Poppins,
+    Raleway,
+    Playfair_Display,
+    Merriweather,
+    Ubuntu,
+    Dancing_Script,
+    Pacifico,
+    Cinzel,
+    Rubik,
+    Oswald,
+    Noto_Serif,
+    Lobster,
 } from "next/font/google";
 
 import { FontStyleControls, AlignmentControls, FontSizeControls, FontDropdown, ColorPalettePicker } from "../molecules";
 import { NoWrapToggle } from "../atoms";
 
 import { Style } from "@/types/Style";
+import { TextStyles } from "@/types";
 
 import { colors } from "@/constants/colors";
 
 // ───────────────────────────────────────── fonts array
-const roboto          = Roboto({ subsets: ["latin"], weight: ["400","700"] });
-const openSans        = Open_Sans({ subsets: ["latin"], weight: ["400","700"] });
-const lato            = Lato({ subsets: ["latin"], weight: ["400","700"] });
-const montserrat      = Montserrat({ subsets: ["latin"], weight: ["400","700"] });
-const poppins         = Poppins({ subsets: ["latin"], weight: ["400","700"] });
-const raleway         = Raleway({ subsets: ["latin"], weight: ["400","700"] });
-const playfairDisplay = Playfair_Display({ subsets: ["latin"], weight: ["400","700"] });
-const merriweather    = Merriweather({ subsets: ["latin"], weight: ["400","700"] });
-const ubuntu          = Ubuntu({ subsets: ["latin"], weight: ["400","700"] });
-const dancingScript   = Dancing_Script({ subsets: ["latin"], weight: ["400","700"] });
-const pacifico        = Pacifico({ subsets: ["latin"], weight: "400" });
-const cinzel          = Cinzel({ subsets: ["latin"], weight: ["400","700"] });
-const rubik           = Rubik({ subsets: ["latin"], weight: ["400","700"] });
-const oswald          = Oswald({ subsets: ["latin"], weight: ["400","700"] });
-const notoSerif       = Noto_Serif({ subsets: ["latin"], weight: ["400","700"] });
-const lobster         = Lobster({ subsets: ["latin"], weight: "400" });
+const roboto = Roboto({ subsets: ["latin"], weight: ["400", "700"] });
+const openSans = Open_Sans({ subsets: ["latin"], weight: ["400", "700"] });
+const lato = Lato({ subsets: ["latin"], weight: ["400", "700"] });
+const montserrat = Montserrat({ subsets: ["latin"], weight: ["400", "700"] });
+const poppins = Poppins({ subsets: ["latin"], weight: ["400", "700"] });
+const raleway = Raleway({ subsets: ["latin"], weight: ["400", "700"] });
+const playfairDisplay = Playfair_Display({ subsets: ["latin"], weight: ["400", "700"] });
+const merriweather = Merriweather({ subsets: ["latin"], weight: ["400", "700"] });
+const ubuntu = Ubuntu({ subsets: ["latin"], weight: ["400", "700"] });
+const dancingScript = Dancing_Script({ subsets: ["latin"], weight: ["400", "700"] });
+const pacifico = Pacifico({ subsets: ["latin"], weight: "400" });
+const cinzel = Cinzel({ subsets: ["latin"], weight: ["400", "700"] });
+const rubik = Rubik({ subsets: ["latin"], weight: ["400", "700"] });
+const oswald = Oswald({ subsets: ["latin"], weight: ["400", "700"] });
+const notoSerif = Noto_Serif({ subsets: ["latin"], weight: ["400", "700"] });
+const lobster = Lobster({ subsets: ["latin"], weight: "400" });
 
 const FONTS = [
-    { name: "Roboto",           style: roboto.style.fontFamily,          className: roboto.className },
-    { name: "Open Sans",        style: openSans.style.fontFamily,        className: openSans.className },
-    { name: "Lato",             style: lato.style.fontFamily,            className: lato.className },
-    { name: "Montserrat",       style: montserrat.style.fontFamily,      className: montserrat.className },
-    { name: "Poppins",          style: poppins.style.fontFamily,         className: poppins.className },
-    { name: "Raleway",          style: raleway.style.fontFamily,         className: raleway.className },
+    { name: "Roboto", style: roboto.style.fontFamily, className: roboto.className },
+    { name: "Open Sans", style: openSans.style.fontFamily, className: openSans.className },
+    { name: "Lato", style: lato.style.fontFamily, className: lato.className },
+    { name: "Montserrat", style: montserrat.style.fontFamily, className: montserrat.className },
+    { name: "Poppins", style: poppins.style.fontFamily, className: poppins.className },
+    { name: "Raleway", style: raleway.style.fontFamily, className: raleway.className },
     { name: "Playfair Display", style: playfairDisplay.style.fontFamily, className: playfairDisplay.className },
-    { name: "Merriweather",     style: merriweather.style.fontFamily,    className: merriweather.className },
-    { name: "Ubuntu",           style: ubuntu.style.fontFamily,          className: ubuntu.className },
-    { name: "Dancing Script",   style: dancingScript.style.fontFamily,   className: dancingScript.className },
-    { name: "Pacifico",         style: pacifico.style.fontFamily,        className: pacifico.className },
-    { name: "Cinzel",           style: cinzel.style.fontFamily,          className: cinzel.className },
-    { name: "Rubik",            style: rubik.style.fontFamily,           className: rubik.className },
-    { name: "Oswald",           style: oswald.style.fontFamily,          className: oswald.className },
-    { name: "Noto Serif",       style: notoSerif.style.fontFamily,       className: notoSerif.className },
-    { name: "Lobster",          style: lobster.style.fontFamily,         className: lobster.className },
+    { name: "Merriweather", style: merriweather.style.fontFamily, className: merriweather.className },
+    { name: "Ubuntu", style: ubuntu.style.fontFamily, className: ubuntu.className },
+    { name: "Dancing Script", style: dancingScript.style.fontFamily, className: dancingScript.className },
+    { name: "Pacifico", style: pacifico.style.fontFamily, className: pacifico.className },
+    { name: "Cinzel", style: cinzel.style.fontFamily, className: cinzel.className },
+    { name: "Rubik", style: rubik.style.fontFamily, className: rubik.className },
+    { name: "Oswald", style: oswald.style.fontFamily, className: oswald.className },
+    { name: "Noto Serif", style: notoSerif.style.fontFamily, className: notoSerif.className },
+    { name: "Lobster", style: lobster.style.fontFamily, className: lobster.className },
 ];
 
 // ───────────────────────────────────────── props
 interface FontControlsProps {
-    toggleStyle:     (s:"bold"|"italic"|"underline"|"strikethrough")=>void;
-    changeAlignment: (a:"left"|"center"|"right"|"justify")=>void;
-    changeFontSize:  (n:number)=>void;
+    toggleStyle: (s: "bold" | "italic" | "underline" | "strikethrough") => void;
+    changeAlignment: (a: "left" | "center" | "right" | "justify") => void;
+    changeFontSize: (n: number) => void;
     currentFontSize: number;
-    changeTextColor: (c:string)=>void;
-    changeFontFamily:(f:string)=>void;
-    noWrap:          boolean;
-    toggleNoWrap:    () => void;
+    changeTextColor: (c: string) => void;
+    changeFontFamily: (f: string) => void;
+    noWrap: boolean;
+    toggleNoWrap: () => void;
+    textStyles: TextStyles;
 }
 
 // ───────────────────────────────────────── component
 const FontControls: React.FC<FontControlsProps> = ({
-                                                       toggleStyle,
-                                                       changeAlignment,
-                                                       changeFontSize,
-                                                       currentFontSize,
-                                                       changeTextColor,
-                                                       changeFontFamily,
-                                                       noWrap,
-                                                       toggleNoWrap,
-                                                   }) => {
-    const [selectedFontSize,  setSelectedFontSize]  = useState(currentFontSize);
-    const [selectedFont,      setSelectedFont]      = useState("Arial");
+    toggleStyle,
+    changeAlignment,
+    changeFontSize,
+    currentFontSize,
+    changeTextColor,
+    changeFontFamily,
+    noWrap,
+    toggleNoWrap,
+    textStyles,
+}) => {
+    const [selectedFontSize, setSelectedFontSize] = useState(currentFontSize);
+    const [selectedFont, setSelectedFont] = useState(textStyles.fontFamily);
+    const [selectedColor, setSelectedColor] = useState(textStyles.textColor);
+    const [alignment, setAlignment] = useState(textStyles.alignment);
 
-    const setSize  = (n:number) => { setSelectedFontSize(n); changeFontSize(n); };
-    const setFont  = (f:string) => { setSelectedFont(f);    changeFontFamily(f); };
-
-    const [activeStyles, setActiveStyles] = useState<Style[]>([]);
-
-    const handleToggleStyle = (s: Style) => {
-        setActiveStyles(prev =>
-            prev.includes(s) ? prev.filter(x => x !== s) : [...prev, s]
-        );
-
-        toggleStyle(s);
+    const setSize = (n: number) => {
+        setSelectedFontSize(n);
+        changeFontSize(n);
     };
 
+    const setFont = (fontFamily: string) => {
+        setSelectedFont(fontFamily);
+        changeFontFamily(fontFamily);
+    };
+
+    const handleColorChange = (color: string) => {
+        setSelectedColor(color);
+        changeTextColor(color);
+    };
+
+    const handleAlignmentChange = (value: "left" | "center" | "right" | "justify") => {
+        setAlignment(value);
+        changeAlignment(value);
+    };
+
+    const derivedActiveStyles = useMemo<Style[]>(() => {
+        const initial: Style[] = [];
+        if (textStyles.bold) initial.push("bold");
+        if (textStyles.italic) initial.push("italic");
+        if (textStyles.underline) initial.push("underline");
+        if (textStyles.strikethrough) initial.push("strikethrough");
+        return initial;
+    }, [textStyles.bold, textStyles.italic, textStyles.underline, textStyles.strikethrough]);
+
+    const [activeStyles, setActiveStyles] = useState<Style[]>(derivedActiveStyles);
+
+    useEffect(() => {
+        setActiveStyles(derivedActiveStyles);
+    }, [derivedActiveStyles]);
+
+    const handleToggleStyle = (style: Style) => {
+        setActiveStyles((prev) =>
+            prev.includes(style) ? prev.filter((entry) => entry !== style) : [...prev, style]
+        );
+        toggleStyle(style);
+    };
+
+    useEffect(() => {
+        setSelectedFontSize(currentFontSize);
+    }, [currentFontSize]);
+
+    useEffect(() => {
+        setSelectedFont(textStyles.fontFamily);
+    }, [textStyles.fontFamily]);
+
+    useEffect(() => {
+        setSelectedColor(textStyles.textColor);
+    }, [textStyles.textColor]);
+
+    useEffect(() => {
+        setAlignment(textStyles.alignment);
+    }, [textStyles.alignment]);
+
     return (
-        <div>
+        <div className="flex flex-col gap-6">
             {/* Stil */}
             <Section title="Schriftstil">
-                <FontStyleControls value={activeStyles} toggleStyle={handleToggleStyle}/>
+                <FontStyleControls value={activeStyles} toggleStyle={handleToggleStyle} />
             </Section>
 
             {/* Ausrichtung */}
             <Section title="Ausrichtung">
-                <AlignmentControls onChange={changeAlignment}/>
+                <AlignmentControls onChange={handleAlignmentChange} value={alignment} />
             </Section>
 
             {/* Zeilenumbruch */}
             <Section title="Zeilenumbruch">
-                <NoWrapToggle active={!noWrap} onToggle={toggleNoWrap}/>
+                <NoWrapToggle active={!noWrap} onToggle={toggleNoWrap} />
             </Section>
 
             {/* Größe */}
             <Section title="Schriftgröße">
-                <FontSizeControls value={selectedFontSize} onChange={setSize}/>
+                <FontSizeControls value={selectedFontSize} onChange={setSize} />
             </Section>
 
             {/* Font‑Family */}
             <Section title="Schriftart">
-                <FontDropdown fonts={FONTS} selectedFontFamily={selectedFont} onFontChange={setFont}/>
+                <FontDropdown fonts={FONTS} selectedFontFamily={selectedFont} onFontChange={setFont} />
             </Section>
 
             {/* Farbe */}
             <Section title="Textfarbe">
-                <ColorPalettePicker colors={colors} onChange={changeTextColor}/>
+                <ColorPalettePicker colors={colors} onChange={handleColorChange} selectedColor={selectedColor} />
             </Section>
         </div>
     );
@@ -128,9 +191,11 @@ const FontControls: React.FC<FontControlsProps> = ({
 export default FontControls;
 
 // ───────────────────────────────────────── small helper
-const Section:React.FC<{title:string,children:React.ReactNode}> = ({title,children}) => (
-    <>
-        <h2 className="text-lg font-semibold my-4 text-gray-800 dark:text-gray-200">{title}</h2>
+const Section: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
+    <section className="space-y-3">
+        <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-[#A1E2F8]">
+            {title}
+        </h2>
         {children}
-    </>
+    </section>
 );


### PR DESCRIPTION
## Summary
- shrink the pattern selector tiles and decouple their preview scale from the pattern slider
- restyle the color picker popover to match the creator UI and open upward from its trigger
- overhaul the font options panel with synchronized state, compact controls, and highlighted selections

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e638b0652c8324945d249ff607cec4