### PR TITLE
Adjust sidebar layout width

### DIFF
--- a/src/app/creator/page.tsx
+++ b/src/app/creator/page.tsx
@@ -130,7 +130,7 @@ const CreatorPage = () => {
                     className="relative flex flex-col gap-8"
                 >
                     <div className="relative flex flex-col gap-8 xl:flex-row xl:items-stretch xl:gap-10">
-                        <div className="xl:w-[320px] xl:flex-shrink-0">
+                        <div className="xl:max-w-[280px] xl:flex-shrink-0">
                             <Sidebar
                                 toggleStyle={toggleStyle}
                                 changeFontSize={changeFontSize}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -38,7 +38,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 
     return (
         <aside
-            className="relative flex h-full w-full flex-col gap-6 rounded-[26px] border border-white/10 bg-black/40 p-6 backdrop-blur-xl shadow-[0_20px_60px_-30px_rgba(192,230,244,0.55)] transition duration-150"
+            className="relative flex h-full w-full flex-col gap-6 rounded-[26px] border border-white/10 bg-black/40 p-6 backdrop-blur-xl shadow-[0_20px_60px_-30px_rgba(192,230,244,0.55)] transition duration-150 lg:max-w-[260px] xl:max-w-[280px]"
         >
             {/* Typografie-Kontrollen */}
             <FontControls


### PR DESCRIPTION
## Summary
- tighten the creator sidebar container so it no longer spans an overly wide column
- cap the sidebar card width on larger breakpoints for a more balanced layout

## Testing
- npm run lint *(fails: pre-existing lint warning about unused Rocket import in src/app/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e643691b608324ac355e14e81a6b68