### PR TITLE
Improve creator layout cross-browser

### DIFF
--- a/src/app/creator/page.tsx
+++ b/src/app/creator/page.tsx
@@ -129,8 +129,8 @@ const CreatorPage = () => {
                     transition={{ duration: 0.7 }}
                     className="relative flex flex-col gap-8"
                 >
-                    <div className="relative flex flex-col gap-8 xl:flex-row xl:items-stretch xl:gap-10">
-                        <div className="xl:w-[320px] xl:flex-shrink-0">
+                    <div className="relative flex flex-col gap-8 xl:grid xl:grid-cols-[minmax(0,280px)_1fr] xl:items-start xl:gap-10">
+                        <div className="w-full xl:w-[280px]">
                             <Sidebar
                                 toggleStyle={toggleStyle}
                                 changeFontSize={changeFontSize}
@@ -145,7 +145,7 @@ const CreatorPage = () => {
                             />
                         </div>
 
-                        <div className="flex flex-1 flex-col gap-8">
+                        <div className="flex min-w-0 flex-1 flex-col gap-8">
                             <div className="w-full rounded-3xl border border-[#A1E2F8]/20 bg-white/5 p-6 backdrop-blur-xl shadow-[0_25px_80px_-35px_rgba(192,230,244,0.55)]">
                                 <div className="mb-4 flex items-center justify-between text-sm uppercase tracking-[0.35em] text-[#A1E2F8]/70">
                                     <span>Preview</span>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -38,7 +38,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 
     return (
         <aside
-            className="relative flex h-full w-full flex-col gap-6 rounded-[26px] border border-white/10 bg-black/40 p-6 backdrop-blur-xl shadow-[0_20px_60px_-30px_rgba(192,230,244,0.55)] transition duration-150"
+            className="relative flex h-full w-full flex-col gap-6 rounded-[26px] border border-white/10 bg-black/40 p-6 backdrop-blur-xl shadow-[0_20px_60px_-30px_rgba(192,230,244,0.55)] transition duration-150 lg:max-w-[260px] xl:max-w-[280px]"
         >
             {/* Typografie-Kontrollen */}
             <FontControls

--- a/src/components/atoms/NoWrapToggle.tsx
+++ b/src/components/atoms/NoWrapToggle.tsx
@@ -8,8 +8,8 @@ interface Props {
 
 export const NoWrapToggle: React.FC<Props> = ({ active, onToggle }) => (
     <div className="flex">
-        <GlassButton active={active} onClick={onToggle} aria-label="Zeilenumbruch umschalten" padding="10px 12px">
-            <MdWrapText className="text-lg" />
+        <GlassButton active={active} onClick={onToggle} aria-label="Zeilenumbruch umschalten" padding="9px 10px">
+            <MdWrapText className="text-base" />
         </GlassButton>
     </div>
 );

--- a/src/components/molecules/FontSizeControls.tsx
+++ b/src/components/molecules/FontSizeControls.tsx
@@ -24,7 +24,7 @@ export const FontSizeControls: React.FC<Props> = ({ value, onChange }) => {
 
     return (
         <div className="space-y-6">
-            <div className="flex flex-wrap gap-x-16 gap-y-10 pl-6 pt-6 pb-6">
+            <div className="grid grid-cols-3 gap-x-4 gap-y-5 px-4 pt-6 pb-4 sm:grid-cols-4 lg:grid-cols-6">
                 {PRESET.map((n) => (
                     <GlassButton key={n} active={local === n} onClick={() => apply(n)} isText padding="10px 14px">
                         {n}


### PR DESCRIPTION
## Summary
- tighten the creator sidebar container so it no longer spans an overly wide column
- cap the sidebar card width on larger breakpoints for a more balanced layout
- switch the creator layout to a two-column grid and allow the preview column to shrink so Safari renders the layout correctly
- make the font size presets grid-based with tighter spacing and resize the line break toggle icon to match the design

## Testing
- npm run lint *(fails: pre-existing unused Rocket import in src/app/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e643691b608324ac355e14e81a6b68