### PR TITLE
Add new static and animated patterns to banner picker

### DIFF
--- a/src/app/creator/page.tsx
+++ b/src/app/creator/page.tsx
@@ -7,8 +7,8 @@ import { motion } from "framer-motion";
 import Sidebar from "@/components/Sidebar/Sidebar";
 import BannerPreview from "@/components/Preview/BannerPreview";
 import SettingsPanel from "@/components/Settings/SettingsPanel";
-import { patterns } from "@/constants/patterns";
-import { TextStyles } from "@/types";
+import { animatedPatterns, patterns } from "@/constants/patterns";
+import { Pattern, TextStyles } from "@/types";
 import { parseCSS } from "@/utils/parseCSS";
 
 const CreatorPage = () => {
@@ -32,6 +32,35 @@ const CreatorPage = () => {
     const [visiblePicker, setVisiblePicker] = useState<string | null>(null);
     const previewRef = useRef<HTMLDivElement>(null);
     const darkMode = true;
+
+    const renderPatternButton = (pattern: Pattern) => {
+        const isSelected = pattern.name === selectedPattern.name;
+        return (
+            <button
+                key={pattern.name}
+                type="button"
+                onClick={() => setSelectedPattern(pattern)}
+                className={`group relative overflow-hidden rounded-2xl border ${
+                    isSelected ? "border-[#A1E2F8]" : "border-white/10"
+                } bg-white/5 p-2.5 text-left transition hover:border-[#A1E2F8]/60`}
+            >
+                <div
+                    className={`relative h-20 w-full overflow-hidden rounded-lg border border-white/10 ${
+                        pattern.className ?? ""
+                    }`}
+                    style={parseCSS(pattern.style, 14, patternColor1, patternColor2)}
+                />
+                <div className="mt-3 flex items-center justify-between gap-2">
+                    <span className="text-sm font-medium text-white">{pattern.name}</span>
+                    {pattern.isAnimated && (
+                        <span className="rounded-full bg-[#A1E2F8]/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.35em] text-[#A1E2F8]">
+                            ∞ GIF
+                        </span>
+                    )}
+                </div>
+            </button>
+        );
+    };
 
     const toggleStyle = (style: "bold" | "italic" | "underline" | "strikethrough") => {
         setTextStyles((prev) => ({
@@ -171,28 +200,27 @@ const CreatorPage = () => {
                                     <p className="mt-2 text-sm text-white/60">
                                         Feine Texturen für lebendige Banner. Justiere Farben und Skalierung, um deinen Look zu perfektionieren.
                                     </p>
-                                    <div className="mt-6 max-h-[13rem] overflow-y-auto pr-2">
-                                        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-                                            {patterns.map((pattern) => (
-                                                <button
-                                                    key={pattern.name}
-                                                    type="button"
-                                                    onClick={() => setSelectedPattern(pattern)}
-                                                    className={`group relative overflow-hidden rounded-2xl border ${
-                                                        pattern.name === selectedPattern.name
-                                                            ? "border-[#A1E2F8]"
-                                                            : "border-white/10"
-                                                    } bg-white/5 p-2.5 text-left transition hover:border-[#A1E2F8]/60`}
-                                                >
-                                                    <div
-                                                        className="h-20 w-full rounded-lg border border-white/10"
-                                                        style={parseCSS(pattern.style, 14, patternColor1, patternColor2)}
-                                                    />
-                                                    <span className="mt-3 block text-sm font-medium text-white">
-                                                        {pattern.name}
+                                    <div className="mt-6 max-h-[20rem] overflow-y-auto pr-2">
+                                        <div className="space-y-6">
+                                            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                                                {patterns.map((pattern) => renderPatternButton(pattern))}
+                                            </div>
+                                            <div>
+                                                <div className="flex items-center justify-between">
+                                                    <h3 className="text-xs font-semibold uppercase tracking-[0.45em] text-white/60">
+                                                        Animierte Hintergründe
+                                                    </h3>
+                                                    <span className="text-[11px] uppercase tracking-[0.4em] text-[#A1E2F8]">
+                                                        ∞ GIF
                                                     </span>
-                                                </button>
-                                            ))}
+                                                </div>
+                                                <p className="mt-2 text-xs text-white/60">
+                                                    Diese Hintergründe laufen dauerhaft in einer Endlosschleife.
+                                                </p>
+                                                <div className="mt-3 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                                                    {animatedPatterns.map((pattern) => renderPatternButton(pattern))}
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -69,3 +69,483 @@ body {
   font-size: 11px;
   @apply bg-background/90 text-foreground shadow-sm select-none pointer-events-none;
 }
+
+.pattern-surface {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.pattern-surface::before,
+.pattern-surface::after {
+  pointer-events: none;
+}
+
+.animated-bg-hiii {
+  position: relative;
+  overflow: hidden;
+  background: #000;
+}
+
+.animated-bg-hiii::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background-image: radial-gradient(
+    circle at 50% 50%,
+    #0000 0,
+    #0000 2px,
+    hsl(0 0 4%) 2px
+  );
+  background-size: 8px 8px;
+  animation: 5s ease-in-out hiii infinite;
+  --f: blur(3em) brightness(9);
+}
+
+.animated-bg-hiii::before {
+  content: "";
+  position: absolute;
+  inset: -145%;
+  z-index: 0;
+  transform: rotate(-45deg);
+  --c: #fa0;
+  --c1: #f00;
+  background-image:
+    radial-gradient(4px 100px at 0px 235px, var(--c), #0000),
+    radial-gradient(4px 100px at 300px 235px, var(--c), #0000),
+    radial-gradient(3px 4px at 150px 117.5px, var(--c1) 100%, #0000 150%),
+    radial-gradient(4px 100px at 0px 252px, var(--c), #0000),
+    radial-gradient(4px 100px at 300px 252px, var(--c), #0000),
+    radial-gradient(3px 4px at 150px 126px, var(--c1) 100%, #0000 150%),
+    radial-gradient(4px 100px at 0px 150px, var(--c), #0000),
+    radial-gradient(4px 100px at 300px 150px, var(--c), #0000),
+    radial-gradient(3px 4px at 150px 75px, var(--c1) 100%, #0000 150%),
+    radial-gradient(4px 100px at 0px 253px, var(--c), #0000),
+    radial-gradient(4px 100px at 300px 253px, var(--c), #0000),
+    radial-gradient(3px 4px at 150px 126.5px, var(--c1) 100%, #0000 150%),
+    radial-gradient(4px 100px at 0px 204px, var(--c), #0000),
+    radial-gradient(4px 100px at 300px 204px, var(--c), #0000),
+    radial-gradient(3px 4px at 150px 102px, var(--c1) 100%, #0000 150%),
+    radial-gradient(4px 100px at 0px 134px, var(--c), #0000),
+    radial-gradient(4px 100px at 300px 134px, var(--c), #0000),
+    radial-gradient(3px 4px at 150px 67px, var(--c1) 100%, #0000 150%),
+    radial-gradient(4px 100px at 0px 179px, var(--c), #0000),
+    radial-gradient(4px 100px at 300px 179px, var(--c), #0000),
+    radial-gradient(3px 4px at 150px 89.5px, var(--c1) 100%, #0000 150%),
+    radial-gradient(4px 100px at 0px 299px, var(--c), #0000),
+    radial-gradient(4px 100px at 300px 299px, var(--c), #0000),
+    radial-gradient(3px 4px at 150px 149.5px, var(--c1) 100%, #0000 150%),
+    radial-gradient(4px 100px at 0px 215px, var(--c), #0000),
+    radial-gradient(4px 100px at 300px 215px, var(--c), #0000),
+    radial-gradient(3px 4px at 150px 107.5px, var(--c1) 100%, #0000 150%),
+    radial-gradient(4px 100px at 0px 281px, var(--c), #0000),
+    radial-gradient(4px 100px at 300px 281px, var(--c), #0000),
+    radial-gradient(3px 4px at 150px 140.5px, var(--c1) 100%, #0000 150%),
+    radial-gradient(4px 100px at 0px 158px, var(--c), #0000),
+    radial-gradient(4px 100px at 300px 158px, var(--c), #0000),
+    radial-gradient(3px 4px at 150px 79px, var(--c1) 100%, #0000 150%),
+    radial-gradient(4px 100px at 0px 210px, var(--c), #0000),
+    radial-gradient(4px 100px at 300px 210px, var(--c), #0000),
+    radial-gradient(3px 4px at 150px 105px, var(--c1) 100%, #0000 150%);
+  background-size:
+    300px 235px,
+    300px 235px,
+    300px 235px,
+    300px 252px,
+    300px 252px,
+    300px 252px,
+    300px 150px,
+    300px 150px,
+    300px 150px,
+    300px 253px,
+    300px 253px,
+    300px 253px,
+    300px 204px,
+    300px 204px,
+    300px 204px,
+    300px 134px,
+    300px 134px,
+    300px 134px,
+    300px 179px,
+    300px 179px,
+    300px 179px,
+    300px 299px,
+    300px 299px,
+    300px 299px,
+    300px 215px,
+    300px 215px,
+    300px 215px,
+    300px 281px,
+    300px 281px,
+    300px 281px,
+    300px 158px,
+    300px 158px,
+    300px 158px,
+    300px 210px,
+    300px 210px,
+    300px 210px;
+  animation: hi 150s linear infinite;
+}
+
+@keyframes hiii {
+  0% {
+    backdrop-filter: var(--f) hue-rotate(0deg);
+  }
+  25% {
+    backdrop-filter: var(--f) hue-rotate(-25deg);
+  }
+  28% {
+    backdrop-filter: var(--f) hue-rotate(0deg);
+  }
+  32% {
+    backdrop-filter: var(--f) hue-rotate(-20deg);
+  }
+  39% {
+    backdrop-filter: var(--f) hue-rotate(0deg);
+  }
+  40% {
+    backdrop-filter: var(--f) hue-rotate(-20deg);
+  }
+  41% {
+    backdrop-filter: var(--f) hue-rotate(0deg);
+  }
+  42% {
+    backdrop-filter: var(--f) hue-rotate(-25deg);
+  }
+  44% {
+    backdrop-filter: var(--f) hue-rotate(0deg);
+  }
+  58% {
+    backdrop-filter: var(--f) hue-rotate(-20deg);
+  }
+  64% {
+    backdrop-filter: var(--f) hue-rotate(0deg);
+  }
+  80% {
+    backdrop-filter: var(--f) hue-rotate(-25deg);
+  }
+  to {
+    backdrop-filter: var(--f) hue-rotate(0deg);
+  }
+}
+
+@keyframes hi {
+  0% {
+    background-position:
+      0px 220px,
+      3px 220px,
+      151.5px 337.5px,
+      25px 24px,
+      28px 24px,
+      176.5px 150px,
+      50px 16px,
+      53px 16px,
+      201.5px 91px,
+      75px 224px,
+      78px 224px,
+      226.5px 350.5px,
+      100px 19px,
+      103px 19px,
+      251.5px 121px,
+      125px 120px,
+      128px 120px,
+      276.5px 187px,
+      150px 31px,
+      153px 31px,
+      301.5px 120.5px,
+      175px 235px,
+      178px 235px,
+      326.5px 384.5px,
+      200px 121px,
+      203px 121px,
+      351.5px 228.5px,
+      225px 224px,
+      228px 224px,
+      376.5px 364.5px,
+      250px 26px,
+      253px 26px,
+      401.5px 105px,
+      275px 75px,
+      278px 75px,
+      426.5px 180px;
+  }
+  to {
+    background-position:
+      0px 6800px,
+      3px 6800px,
+      151.5px 6917.5px,
+      25px 13632px,
+      28px 13632px,
+      176.5px 13758px,
+      50px 5416px,
+      53px 5416px,
+      201.5px 5491px,
+      75px 17175px,
+      78px 17175px,
+      226.5px 17301.5px,
+      100px 5119px,
+      103px 5119px,
+      251.5px 5221px,
+      125px 8428px,
+      128px 8428px,
+      276.5px 8495px,
+      150px 9876px,
+      153px 9876px,
+      301.5px 9965.5px,
+      175px 13391px,
+      178px 13391px,
+      326.5px 13540.5px,
+      200px 14741px,
+      203px 14741px,
+      351.5px 14848.5px,
+      225px 18770px,
+      228px 18770px,
+      376.5px 18910.5px,
+      250px 5082px,
+      253px 5082px,
+      401.5px 5161px,
+      275px 6375px,
+      278px 6375px,
+      426.5px 6480px;
+  }
+}
+
+.animated-bg-g2 {
+  position: relative;
+  overflow: hidden;
+  --s: 56px;
+  --g: 10px;
+  --c: #ECD078;
+  --_l: #0000 calc(33% - .866*var(--g)), var(--c) calc(33.2% - .866*var(--g)) 33%, #0000 34%;
+  background:
+    repeating-linear-gradient(var(--c) 0 var(--g), #0000 0 50%) 0 calc(.866*var(--s) - var(--g)/2),
+    conic-gradient(from -150deg at var(--g) 50%, var(--c) 120deg, #0000 0),
+    linear-gradient(-120deg, var(--_l)),
+    linear-gradient(-60deg, var(--_l))
+    #0B486B;
+  background-size: var(--s) calc(3.466*var(--s));
+  animation: g2 2s linear infinite;
+}
+
+@keyframes g2 {
+  to {
+    background-position-x: calc(-1 * var(--s));
+  }
+}
+
+.animated-bg-g1 {
+  position: relative;
+  overflow: hidden;
+  --s: 50px;
+  --c1: #5E412F;
+  --c2: #FCEBB6;
+  background:
+    radial-gradient(25% 50%, var(--c1) 98%, #0000) var(--s) 0 / calc(2 * var(--s)) var(--s),
+    radial-gradient(25% 50%, var(--c2) 98%, #0000) 0 0 / calc(2 * var(--s)) var(--s),
+    repeating-conic-gradient(var(--c1) 0 25%, var(--c2) 0 50%) 0 0 / calc(2 * var(--s)) calc(2 * var(--s));
+  animation: g1 2s linear infinite;
+}
+
+@keyframes g1 {
+  to {
+    background-position: calc(3 * var(--s)) 0, calc(2 * var(--s)) 0, calc(2 * var(--s)) 0;
+  }
+}
+
+.animated-bg-g4 {
+  position: relative;
+  overflow: hidden;
+  --s: 140px;
+  --c1: #AB3E5B;
+  --c2: #FFBE40;
+  --_g: #0000 25%, #0008 47%, var(--c1) 53% 147%, var(--c2) 153% 247%, var(--c1) 253% 347%, var(--c2) 353% 447%, var(--c1) 453% 547%, #0008 553%, #0000 575%;
+  --_s: calc(25%/3) calc(25%/4) at 50%;
+  background:
+    radial-gradient(var(--_s) 100%, var(--_g)),
+    radial-gradient(var(--_s) 100%, var(--_g)) calc(var(--s)/2) calc(3 * var(--s) / 4),
+    radial-gradient(var(--_s) 0, var(--_g)) calc(var(--s)/2) 0,
+    radial-gradient(var(--_s) 0, var(--_g)) 0 calc(3 * var(--s) / 4),
+    repeating-linear-gradient(90deg, #ACCEC0 calc(25% / -6) calc(25% / 6), #61A6AB 0 calc(25% / 2));
+  background-size: var(--s) calc(3 * var(--s) / 2);
+  animation: g4 2.5s infinite linear;
+}
+
+@keyframes g4 {
+  to {
+    background-position:
+      var(--s) 0,
+      calc(var(--s) / -2) calc(3 * var(--s) / 4),
+      calc(3 * var(--s) / 2) 0,
+      calc(-1 * var(--s)) calc(3 * var(--s) / 4),
+      0 0;
+  }
+}
+
+.animated-bg-g6 {
+  position: relative;
+  overflow: hidden;
+  --s: 100px;
+  --c1: #C3CCAF;
+  --c2: #67434F;
+  --_s: calc(2 * var(--s)) calc(2 * var(--s));
+  --_g: var(--_s) conic-gradient(at 40% 40%, #0000 75%, var(--c1) 0);
+  --_p: var(--_s) conic-gradient(at 20% 20%, #0000 75%, var(--c2) 0);
+  background:
+    calc(.9 * var(--s)) calc(.9 * var(--s)) / var(--_p),
+    calc(-.1 * var(--s)) calc(-.1 * var(--s)) / var(--_p),
+    calc(.7 * var(--s)) calc(.7 * var(--s)) / var(--_g),
+    calc(-.3 * var(--s)) calc(-.3 * var(--s)) / var(--_g),
+    conic-gradient(from 90deg at 20% 20%, var(--c2) 25%, var(--c1) 0) 0 0 / var(--s) var(--s);
+  animation: g6 3s infinite;
+}
+
+@keyframes g6 {
+  0% {
+    background-position:
+      calc(.9 * var(--s)) calc(.9 * var(--s)),
+      calc(-.1 * var(--s)) calc(-.1 * var(--s)),
+      calc(.7 * var(--s)) calc(.7 * var(--s)),
+      calc(-.3 * var(--s)) calc(-.3 * var(--s)),
+      0 0;
+  }
+  25% {
+    background-position:
+      calc(1.9 * var(--s)) calc(.9 * var(--s)),
+      calc(-1.1 * var(--s)) calc(-.1 * var(--s)),
+      calc(1.7 * var(--s)) calc(.7 * var(--s)),
+      calc(-1.3 * var(--s)) calc(-.3 * var(--s)),
+      0 0;
+  }
+  50% {
+    background-position:
+      calc(1.9 * var(--s)) calc(-.1 * var(--s)),
+      calc(-1.1 * var(--s)) calc(.9 * var(--s)),
+      calc(1.7 * var(--s)) calc(-.3 * var(--s)),
+      calc(-1.3 * var(--s)) calc(.7 * var(--s)),
+      0 0;
+  }
+  75% {
+    background-position:
+      calc(2.9 * var(--s)) calc(-.1 * var(--s)),
+      calc(-2.1 * var(--s)) calc(.9 * var(--s)),
+      calc(2.7 * var(--s)) calc(-.3 * var(--s)),
+      calc(-2.3 * var(--s)) calc(.7 * var(--s)),
+      0 0;
+  }
+  100% {
+    background-position:
+      calc(2.9 * var(--s)) calc(-1.1 * var(--s)),
+      calc(-2.1 * var(--s)) calc(1.9 * var(--s)),
+      calc(2.7 * var(--s)) calc(-1.3 * var(--s)),
+      calc(-2.3 * var(--s)) calc(1.7 * var(--s)),
+      0 0;
+  }
+}
+
+.animated-bg-g8 {
+  position: relative;
+  overflow: hidden;
+  --b: 4px;
+  --s: 60px;
+  --c: #0000 75%, #999 0;
+  --p1: from -90deg at calc(50% + var(--b)) calc(100% - var(--b));
+  --p2: from -90deg at var(--b) calc(50% - var(--b));
+  --e: calc(var(--s) / 2);
+  --e-: calc(var(--s) / -2);
+  background:
+    conic-gradient(var(--p1), var(--c)),
+    conic-gradient(var(--p1), var(--c)),
+    conic-gradient(var(--p2), var(--c)),
+    conic-gradient(var(--p2), var(--c)),
+    #111;
+  background-size: var(--s) var(--s);
+  animation: g8 10s infinite;
+}
+
+@keyframes g8 {
+  0%,
+  2% {
+    background-position: 0 0, var(--e) var(--e), 0 0, var(--e) var(--e);
+  }
+  10%,
+  15% {
+    background-position: 0 0, var(--e) var(--e), 0 var(--e), var(--e) 0;
+  }
+  22.5%,
+  27.5% {
+    background-position: var(--e) 0, 0 var(--e), 0 var(--e), var(--e) 0;
+  }
+  35%,
+  40% {
+    background-position: var(--e) 0, 0 var(--e), 0 0, var(--e) var(--e-);
+  }
+  47.5%,
+  52.5% {
+    background-position: 0 0, var(--e-) var(--e), 0 0, var(--e) var(--e-);
+  }
+  60%,
+  65% {
+    background-position: 0 0, var(--e-) var(--e), 0 var(--e-), var(--e) 0;
+  }
+  72.5%,
+  77.5% {
+    background-position: var(--e-) 0, 0 var(--e), 0 var(--e-), var(--e) 0;
+  }
+  85%,
+  90% {
+    background-position: var(--e-) 0, 0 var(--e), 0 0, var(--e) var(--e);
+  }
+  98%,
+  100% {
+    background-position: 0 0, var(--e) var(--e), 0 0, var(--e) var(--e);
+  }
+}
+
+.animated-bg-g16 {
+  position: relative;
+  overflow: hidden;
+  --s: 80px;
+  --c: #6B5344 0;
+  --g: conic-gradient(at 50% 25%, #0000 75%, var(--c));
+  background:
+    repeating-linear-gradient(#0000 0 48%, var(--c) 50%), var(--g),
+    conic-gradient(#0000 75%, var(--c)) calc(var(--s) / 4) calc(var(--s) / 2),
+    var(--g) calc(var(--s) / 2) var(--s) #F8ECC9;
+  background-size: var(--s) var(--s), var(--s) calc(2 * var(--s));
+  animation: g16 2s infinite linear;
+}
+
+@keyframes g16 {
+  to {
+    background-position:
+      0 0,
+      var(--s) 0,
+      calc(var(--s) / 4) calc(var(--s) / 2),
+      calc(var(--s) / -2) var(--s);
+  }
+}
+
+.animated-bg-g17 {
+  position: relative;
+  overflow: hidden;
+  --s: 16px;
+  --c1: #D88A8A;
+  --c2: #474843;
+  --g: #0000 66%, var(--c1) 67% 98%, #0000;
+  background:
+    radial-gradient(30% 50% at 30% 100%, var(--g)),
+    radial-gradient(30% 50% at 70% 0%, var(--g)) var(--s) 0,
+    repeating-linear-gradient(90deg, var(--c1) 0 10%, var(--c2) 0 50%);
+  background-size: calc(10 * var(--s)) calc(6 * var(--s));
+  animation: g17 1.5s infinite linear;
+}
+
+@keyframes g17 {
+  to {
+    background-position:
+      0 calc(-6 * var(--s)),
+      var(--s) calc(6 * var(--s)),
+      0 0;
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { motion } from "framer-motion";
-import { Layers, Rocket, Ruler, Type } from "lucide-react";
+import { Layers, Ruler, Type } from "lucide-react";
 
 const features = [
     {

--- a/src/components/Preview/BannerPreview.tsx
+++ b/src/components/Preview/BannerPreview.tsx
@@ -39,11 +39,13 @@ const BannerPreview: React.FC<BannerPreviewProps> = ({
         cursor: "text",
         outline: "none",
         whiteSpace: textStyles.noWrap ? "nowrap" : "normal",
+        zIndex: 2,
     };
 
     return (
         <div
             ref={previewRef}
+            className={selectedPattern.className ? `pattern-surface ${selectedPattern.className}` : "pattern-surface"}
             style={{
                 ...parseCSS(selectedPattern.style, patternScale, patternColor1, patternColor2),
                 position: "relative",

--- a/src/constants/patterns.ts
+++ b/src/constants/patterns.ts
@@ -1,10 +1,101 @@
-interface Pattern {
-    name: string;
-    style: (scale: number, color1: string, color2: string) => string;
-}
+import { Pattern } from "@/types";
 
 export const patterns: Pattern[] = [
-
+    {
+        name: "Crimson Depth",
+        style: `
+      background: radial-gradient(125% 125% at 50% 100%, #000000 40%, #2b0707 100%);
+      background-color: #000000;
+    `,
+    },
+    {
+        name: "Aurora Dream Corner Whispers",
+        style: `
+      background:
+        radial-gradient(ellipse 85% 65% at 8% 8%, rgba(175, 109, 255, 0.42), transparent 60%),
+        radial-gradient(ellipse 75% 60% at 75% 35%, rgba(255, 235, 170, 0.55), transparent 62%),
+        radial-gradient(ellipse 70% 60% at 15% 80%, rgba(255, 100, 180, 0.40), transparent 62%),
+        radial-gradient(ellipse 70% 60% at 92% 92%, rgba(120, 190, 255, 0.45), transparent 62%),
+        linear-gradient(180deg, #f7eaff 0%, #fde2ea 100%);
+      background-color: #fde2ea;
+    `,
+    },
+    {
+        name: "Aurora Dream Soft Harmony",
+        style: `
+      background:
+        radial-gradient(ellipse 80% 60% at 60% 20%, rgba(175, 109, 255, 0.50), transparent 65%),
+        radial-gradient(ellipse 70% 60% at 20% 80%, rgba(255, 100, 180, 0.45), transparent 65%),
+        radial-gradient(ellipse 60% 50% at 60% 65%, rgba(255, 235, 170, 0.43), transparent 62%),
+        radial-gradient(ellipse 65% 40% at 50% 60%, rgba(120, 190, 255, 0.48), transparent 68%),
+        linear-gradient(180deg, #f7eaff 0%, #fde2ea 100%);
+      background-color: #fde2ea;
+    `,
+    },
+    {
+        name: "Aurora Dream Vivid Bloom",
+        style: `
+      background:
+        radial-gradient(ellipse 80% 60% at 70% 20%, rgba(175, 109, 255, 0.85), transparent 68%),
+        radial-gradient(ellipse 70% 60% at 20% 80%, rgba(255, 100, 180, 0.75), transparent 68%),
+        radial-gradient(ellipse 60% 50% at 60% 65%, rgba(255, 235, 170, 0.98), transparent 68%),
+        radial-gradient(ellipse 65% 40% at 50% 60%, rgba(120, 190, 255, 0.3), transparent 68%),
+        linear-gradient(180deg, #f7eaff 0%, #fde2ea 100%);
+      background-color: #fde2ea;
+    `,
+    },
+    {
+        name: "Diagonal Grid with Light",
+        style: `
+      background-color: #fafafa;
+      background-image:
+        repeating-linear-gradient(45deg, rgba(0, 0, 0, 0.1) 0, rgba(0, 0, 0, 0.1) 1px, transparent 1px, transparent 20px),
+        repeating-linear-gradient(-45deg, rgba(0, 0, 0, 0.1) 0, rgba(0, 0, 0, 0.1) 1px, transparent 1px, transparent 20px);
+      background-size: 40px 40px;
+    `,
+    },
+    {
+        name: "Dark Grid with White Dots",
+        style: `
+      background: #0f172a;
+      background-image:
+        linear-gradient(to right, rgba(255,255,255,0.06) 1px, transparent 1px),
+        linear-gradient(to bottom, rgba(255,255,255,0.06) 1px, transparent 1px),
+        radial-gradient(circle, rgba(255,255,255,0.6) 1px, transparent 1px);
+      background-size: 20px 20px, 20px 20px, 20px 20px;
+      background-position: 0 0, 0 0, 0 0;
+    `,
+    },
+    {
+        name: "Gradient Diagonal Lines",
+        style: `
+      background-color: #000000;
+      background-image:
+        repeating-linear-gradient(45deg, rgba(0, 255, 65, 0.08) 0, rgba(0, 255, 65, 0.08) 1px, transparent 1px, transparent 12px),
+        repeating-linear-gradient(-45deg, rgba(0, 255, 65, 0.08) 0, rgba(0, 255, 65, 0.08) 1px, transparent 1px, transparent 12px),
+        repeating-linear-gradient(90deg, rgba(0, 255, 65, 0.03) 0, rgba(0, 255, 65, 0.03) 1px, transparent 1px, transparent 4px);
+      background-size: 24px 24px, 24px 24px, 8px 8px;
+    `,
+    },
+    {
+        name: "Dark Noise Colors",
+        style: `
+      background: #000000;
+      background-image:
+        radial-gradient(circle at 1px 1px, rgba(139, 92, 246, 0.2) 1px, transparent 0),
+        radial-gradient(circle at 1px 1px, rgba(59, 130, 246, 0.18) 1px, transparent 0),
+        radial-gradient(circle at 1px 1px, rgba(236, 72, 153, 0.15) 1px, transparent 0);
+      background-size: 20px 20px, 30px 30px, 25px 25px;
+      background-position: 0 0, 10px 10px, 15px 5px;
+    `,
+    },
+    {
+        name: "Top Glow Midnight",
+        style: `
+      background: radial-gradient(ellipse 80% 60% at 50% 0%, rgba(120, 180, 255, 0.25), transparent 70%), #000000;
+      background-color: #000000;
+    `,
+    },
     {
         name: "Radial Cross",
         style: (scale: number, color1: string, color2: string) => {
@@ -396,5 +487,51 @@ export const patterns: Pattern[] = [
                   linear-gradient(${color1} ${scale}px, transparent ${scale}px) 0 -1px, 
                   linear-gradient(90deg, ${color1} ${scale}px, ${color2} ${scale}px) -1px 0; 
        background-size: ${scale * 25}px ${scale * 25}px, ${scale * 25}px ${scale * 25}px, ${scale * 12.5}px ${scale * 12.5}px, ${scale * 12.5}px ${scale * 12.5}px;`,
+    },
+];
+
+export const animatedPatterns: Pattern[] = [
+    {
+        name: "Blurred Neon Motion",
+        className: "animated-bg-hiii",
+        isAnimated: true,
+        style: `
+      background-color: #000000;
+    `,
+    },
+    {
+        name: "Golden Hex Flow",
+        className: "animated-bg-g2",
+        isAnimated: true,
+    },
+    {
+        name: "Vintage Wave Spin",
+        className: "animated-bg-g1",
+        isAnimated: true,
+    },
+    {
+        name: "Retro Bloom Shift",
+        className: "animated-bg-g4",
+        isAnimated: true,
+    },
+    {
+        name: "Dual Orbit",
+        className: "animated-bg-g6",
+        isAnimated: true,
+    },
+    {
+        name: "Chrome Lattice",
+        className: "animated-bg-g8",
+        isAnimated: true,
+    },
+    {
+        name: "Sepia Tiles",
+        className: "animated-bg-g16",
+        isAnimated: true,
+    },
+    {
+        name: "Ribbon Drift",
+        className: "animated-bg-g17",
+        isAnimated: true,
     },
 ];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,7 +14,9 @@ export interface TextStyles {
 
 export interface Pattern {
     name: string;
-    style: (scale: number, color1: string, color2: string) => string;
+    style?: string | ((scale: number, color1: string, color2: string) => string);
+    className?: string;
+    isAnimated?: boolean;
 }
 
 export interface SettingsPanelProps {

--- a/src/utils/parseCSS.ts
+++ b/src/utils/parseCSS.ts
@@ -1,10 +1,13 @@
 export function parseCSS(
-    styleInput: string | ((scale: number, color1: string, color2: string) => string),
+    styleInput: string | ((scale: number, color1: string, color2: string) => string) | undefined,
     scale: number,
     color1: string,
     color2: string
 ): React.CSSProperties {
     const styles: { [key: string]: string } = {};
+    if (!styleInput) {
+        return styles;
+    }
     if (typeof styleInput === "function") {
         styleInput = styleInput(scale, color1, color2);
     }


### PR DESCRIPTION
## Summary
- add nine new hero gradients and textures to the pattern list and register dedicated animated backgrounds
- extend the creator pattern picker with reusable rendering logic and a new animated backgrounds section
- add global helper styles and keyframes so animated selections display correctly in previews while keeping text above them

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e644a345488324a1af7747c971c514