### PR TITLE
Fix Safari layout compression for creator sidebar

### DIFF
--- a/src/app/creator/page.tsx
+++ b/src/app/creator/page.tsx
@@ -129,8 +129,8 @@ const CreatorPage = () => {
                     transition={{ duration: 0.7 }}
                     className="relative flex flex-col gap-8"
                 >
-                    <div className="relative flex flex-col gap-8 xl:flex-row xl:items-stretch xl:gap-10">
-                        <div className="xl:w-[320px] xl:flex-shrink-0">
+                    <div className="relative flex flex-col gap-8 xl:grid xl:grid-cols-[minmax(0,260px)_minmax(0,1fr)] xl:items-start xl:gap-10">
+                        <div className="xl:sticky xl:top-10 xl:self-start">
                             <Sidebar
                                 toggleStyle={toggleStyle}
                                 changeFontSize={changeFontSize}
@@ -145,7 +145,7 @@ const CreatorPage = () => {
                             />
                         </div>
 
-                        <div className="flex flex-1 flex-col gap-8">
+                        <div className="flex min-w-0 flex-1 flex-col gap-8">
                             <div className="w-full rounded-3xl border border-[#A1E2F8]/20 bg-white/5 p-6 backdrop-blur-xl shadow-[0_25px_80px_-35px_rgba(192,230,244,0.55)]">
                                 <div className="mb-4 flex items-center justify-between text-sm uppercase tracking-[0.35em] text-[#A1E2F8]/70">
                                     <span>Preview</span>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -38,7 +38,7 @@ const Sidebar: React.FC<SidebarProps> = ({
 
     return (
         <aside
-            className="relative flex h-full w-full flex-col gap-6 rounded-[26px] border border-white/10 bg-black/40 p-6 backdrop-blur-xl shadow-[0_20px_60px_-30px_rgba(192,230,244,0.55)] transition duration-150"
+            className="relative flex h-full w-full flex-col gap-6 rounded-[26px] border border-white/10 bg-black/40 p-6 backdrop-blur-xl shadow-[0_20px_60px_-30px_rgba(192,230,244,0.55)] transition duration-150 lg:w-[260px] lg:flex-none xl:w-[280px]"
         >
             {/* Typografie-Kontrollen */}
             <FontControls

--- a/src/components/atoms/NoWrapToggle.tsx
+++ b/src/components/atoms/NoWrapToggle.tsx
@@ -8,8 +8,8 @@ interface Props {
 
 export const NoWrapToggle: React.FC<Props> = ({ active, onToggle }) => (
     <div className="flex">
-        <GlassButton active={active} onClick={onToggle} aria-label="Zeilenumbruch umschalten" padding="10px 12px">
-            <MdWrapText className="text-lg" />
+        <GlassButton active={active} onClick={onToggle} aria-label="Zeilenumbruch umschalten" padding="12px 14px">
+            <MdWrapText className="text-xl" />
         </GlassButton>
     </div>
 );

--- a/src/components/molecules/FontSizeControls.tsx
+++ b/src/components/molecules/FontSizeControls.tsx
@@ -24,9 +24,16 @@ export const FontSizeControls: React.FC<Props> = ({ value, onChange }) => {
 
     return (
         <div className="space-y-6">
-            <div className="flex flex-wrap gap-x-16 gap-y-10 pl-6 pt-6 pb-6">
+            <div className="grid grid-cols-3 gap-3 px-2 pt-4 sm:grid-cols-4 md:grid-cols-6">
                 {PRESET.map((n) => (
-                    <GlassButton key={n} active={local === n} onClick={() => apply(n)} isText padding="10px 14px">
+                    <GlassButton
+                        key={n}
+                        active={local === n}
+                        onClick={() => apply(n)}
+                        isText
+                        padding="12px 0"
+                        style={{ width: "100%" }}
+                    >
                         {n}
                     </GlassButton>
                 ))}


### PR DESCRIPTION
## Summary
- rework the creator page layout to keep the sidebar width stable across browsers and provide sticky positioning on desktop
- update the sidebar container sizing to use fixed desktop widths instead of max-width constraints
- tighten typography controls by using a responsive grid for font sizes and enlarging the line-break toggle icon

## Testing
- npm run lint *(fails: existing unused Rocket import and Next.js <img> warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68e643691b608324ac355e14e81a6b68