### PR TITLE
Improve sidebar control spacing and alignment

### DIFF
--- a/src/components/atoms/NoWrapToggle.tsx
+++ b/src/components/atoms/NoWrapToggle.tsx
@@ -7,7 +7,7 @@ interface Props {
 }
 
 export const NoWrapToggle: React.FC<Props> = ({ active, onToggle }) => (
-    <div className="flex">
+    <div className="flex py-4">
         <GlassButton active={active} onClick={onToggle} aria-label="Zeilenumbruch umschalten" padding="14px 18px">
             <MdWrapText className="text-xl" />
         </GlassButton>

--- a/src/components/molecules/AlignmentControls.tsx
+++ b/src/components/molecules/AlignmentControls.tsx
@@ -29,7 +29,7 @@ export const AlignmentControls: React.FC<AlignmentControlsProps> = ({ onChange, 
     };
 
     return (
-        <div className="flex flex-wrap gap-x-16 gap-y-8 pl-4 pt-6 pb-6">
+        <div className="flex flex-wrap gap-x-16 gap-y-8 pt-6 pb-6">
             <GlassButton active={local === "left"} onClick={() => handle("left")} aria-label="Links" padding="14px 18px">
                 <MdAlignHorizontalLeft className="text-xl" />
             </GlassButton>

--- a/src/components/molecules/FontSizeControls.tsx
+++ b/src/components/molecules/FontSizeControls.tsx
@@ -24,7 +24,7 @@ export const FontSizeControls: React.FC<Props> = ({ value, onChange }) => {
 
     return (
         <>
-            <div className="flex flex-wrap gap-x-16 gap-y-14 ml-6 mb-12 mt-8">
+            <div className="flex flex-wrap gap-x-16 gap-y-14 pt-6 pb-8">
                 {PRESET.map((n) => (
                     <GlassButton key={n} active={local === n} onClick={() => apply(n)} isText={true} padding={"7px 7px"}>
                         {n}
@@ -39,7 +39,7 @@ export const FontSizeControls: React.FC<Props> = ({ value, onChange }) => {
                 step={1}
                 value={local}
                 onChange={(e) => apply(+e.target.value)}
-                className="w-full accent-indigo-500"
+                className="mt-10 w-full accent-indigo-500"
             />
         </>
     );

--- a/src/components/molecules/FontStyleControls.tsx
+++ b/src/components/molecules/FontStyleControls.tsx
@@ -13,7 +13,7 @@ export const FontStyleControls: React.FC<Props> = ({ value, toggleStyle }) => {
     const isActive = (s: Style) => value.includes(s);
 
     return (
-        <div className="flex flex-wrap gap-x-16 gap-y-8 pl-4 pt-6 pb-6">
+        <div className="flex flex-wrap gap-x-16 gap-y-8 pt-6 pb-6">
             <GlassButton active={isActive("bold")} onClick={() => toggleStyle("bold")} aria-label="Fett" padding="14px 18px">
                 <MdFormatBold className="text-xl" />
             </GlassButton>

--- a/src/components/organisms/FontControls.tsx
+++ b/src/components/organisms/FontControls.tsx
@@ -154,7 +154,7 @@ const FontControls: React.FC<FontControlsProps> = ({
     }, [textStyles.alignment]);
 
     return (
-        <div>
+        <div className="flex flex-col gap-10">
             {/* Stil */}
             <Section title="Schriftstil">
                 <FontStyleControls value={activeStyles} toggleStyle={handleToggleStyle} />
@@ -192,10 +192,12 @@ export default FontControls;
 
 // ───────────────────────────────────────── small helper
 const Section: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
-    <section className="space-y-3">
+    <section className="flex flex-col gap-5">
         <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-[#A1E2F8]">
             {title}
         </h2>
-        {children}
+        <div className="pl-4">
+            {children}
+        </div>
     </section>
 );


### PR DESCRIPTION
## Summary
- add consistent vertical spacing between sidebar sections for clearer separation
- align typography control groups with a shared indentation without disturbing glass button padding
- expand spacing around the font size presets and slider for improved readability

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e655c6c42883249f970d9b2942bb45